### PR TITLE
Change isFolded to make it same as on ios

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ class StickyParalaxHeader extends Component {
         return constants.isAndroid
           ? this.setState(
             {
-              isFolded: true
+              isFolded: false
             },
             scrollNode.scrollTo({ x: 0, y: 0, animated: true })
           )


### PR DESCRIPTION
On android prevent header from resizing when changing tabs in the main menu