### PR TITLE
Customizable logo in TabbedHeader

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ Below are examples of those components and description of the props they are acc
 | `bounces`         | `bool`                |    Yes   | `true`                                                                       | Bounces on swiping up                                    |
 | `snapToEdge`      | `bool`                |    Yes   | `true`                                                                       | Boolean to fire the function for snap To Edge            |
 | `renderBody`      | `func`                |    Yes   | `title => <RenderContent title={title} />`                                   | Function that renders body of the header (can be empty)  |
-| `tabs`            | `arrayOf(shape({}))`  |    Yes   | `[{title: 'Popular',content: <RenderContent title="Popular Quizes" />},...]`,| Array with tabs names and content                        |
+| `tabs`            | `arrayOf(shape({}))`  |    Yes   | `[{title: 'Popular',content: <RenderContent title="Popular Quizes" />},...]`| Array with tabs names and content                        |
+| `logo`            | `func`  |    Yes   | `require('../../assets/images/logo.png')`| Set header logo                        |
+| `logoStyle`            | `style`  |    Yes   | `{ height: 24, width: 142 }`| Set header logo style                        |
+| `logoContainerStyle`            | `style`  |    Yes   | `{    width: '100%', paddingHorizontal: 24, paddingTop: Platform.select({ ios: ifIphoneX(50, 40), android: 55 }), flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center'}`| Set header logo container style                        |
+| `logoResizeMode`            | `"contain", "cover", "stretch", "center", "repeat" `  |    Yes   | `"contain"`,| Set header logo resize mode                        |
 
 
 ## Details Header

--- a/src/predefinedComponents/TabbedHeader/TabbedHeader.js
+++ b/src/predefinedComponents/TabbedHeader/TabbedHeader.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Text, View, Image, StatusBar, Animated } from 'react-native'
+import { Text, View, Image, StatusBar, Animated, ViewPropTypes } from 'react-native'
 import { arrayOf, bool, number, shape, string, func } from 'prop-types'
 import StickyParallaxHeader from '../../index'
 import { constants, colors, sizes } from '../../constants'
@@ -38,14 +38,14 @@ export default class TabbedHeader extends React.Component {
   }
 
   renderHeader = () => {
-    const { backgroundColor } = this.props
+    const { backgroundColor, logo, logoResizeMode, logoStyle, logoContainerStyle } = this.props
 
     return (
-      <View style={[styles.headerWrapper, { backgroundColor }]}>
+      <View style={[logoContainerStyle, { backgroundColor }]}>
         <Image
-          resizeMode="contain"
-          source={require('../../assets/images/logo.png')}
-          style={styles.logo}
+          resizeMode={logoResizeMode}
+          source={logo}
+          style={logoStyle}
         />
       </View>
     )
@@ -167,7 +167,11 @@ TabbedHeader.propTypes = {
   bounces: bool,
   snapToEdge: bool,
   tabs: arrayOf(shape({})),
-  renderBody: func
+  renderBody: func,
+  logo: func,
+  logoResizeMode: string,
+  logoStyle: ViewPropTypes.style,
+  logoContainerStyle: ViewPropTypes.style,
 }
 
 TabbedHeader.defaultProps = {
@@ -177,6 +181,10 @@ TabbedHeader.defaultProps = {
   title: "Mornin' Mark! \nReady for a quiz?",
   bounces: true,
   snapToEdge: true,
+  logo: require('../../assets/images/logo.png'),
+  logoResizeMode: "contain",
+  logoStyle: styles.logo,
+  logoContainerStyle: styles.headerWrapper,
   renderBody: title => <RenderContent title={title} />,
   tabs: [
     {


### PR DESCRIPTION
Added props that enables users to set their own logo instead of Netguru logo.
Also updated readme with those props.

Issues:
https://github.com/netguru/sticky-parallax-header/issues/55