### PR TITLE
fix: scrollNode.scrollTo is not a function. closes #91

### DIFF
--- a/src/StickyParallaxHeader.js
+++ b/src/StickyParallaxHeader.js
@@ -265,7 +265,8 @@ class StickyParallaxHeader extends Component {
       tabTextContainerActiveStyle,
       tabsContainerBackgroundColor,
       tabWrapperStyle,
-      tabsContainerStyle
+      tabsContainerStyle,
+      fixedTabCount //jkl
     } = this.props
     const { scrollValue, currentPage, containerWidth } = this.state
 
@@ -281,7 +282,8 @@ class StickyParallaxHeader extends Component {
       tabsContainerBackgroundColor,
       tabs,
       tabWrapperStyle,
-      tabsContainerStyle
+      tabsContainerStyle,
+      fixedTabCount //jkl
     }
 
     return <ScrollableTabBar {...props} />
@@ -416,7 +418,8 @@ StickyParallaxHeader.propTypes = {
   snapStartThreshold: oneOfType([bool, number]),
   snapStopThreshold: oneOfType([bool, number]),
   snapValue: oneOfType([bool, number]),
-  transparentHeader: bool
+  transparentHeader: bool,
+  fixedTabCount: bool //jkl
 }
 
 StickyParallaxHeader.defaultProps = {

--- a/src/StickyParallaxHeader.js
+++ b/src/StickyParallaxHeader.js
@@ -57,13 +57,13 @@ class StickyParallaxHeader extends Component {
 
   spring = () => {
     const scrollNode = this.scroll
-    scrollNode.scrollTo({ x: 0, y: 40, animated: true })
+    scrollNode.getNode().scrollTo({ x: 0, y: 40, animated: true })
 
     return setTimeout(() => {
       setTimeout(() => {
-        scrollNode.scrollTo({ x: 0, y: 25, animated: true })
+        scrollNode.getNode().scrollTo({ x: 0, y: 25, animated: true })
       }, 200)
-      scrollNode.scrollTo({ x: 0, y: 0, animated: true })
+      scrollNode.getNode().scrollTo({ x: 0, y: 0, animated: true })
     }, 300)
   }
 
@@ -79,7 +79,7 @@ class StickyParallaxHeader extends Component {
     const snapToEdgeAnimatedValue = new ValueXY(scrollValue)
     const snapToEdgeThreshold = snapStartThreshold || height / 2
     const id = snapToEdgeAnimatedValue.addListener((value) => {
-      scrollNode.scrollTo({ x: 0, y: value.y, animated: false })
+      scrollNode.getNode().scrollTo({ x: 0, y: value.y, animated: false })
     })
 
     if (y < -20 && !constants.isAndroid) this.spring(y)
@@ -88,42 +88,42 @@ class StickyParallaxHeader extends Component {
       if (y > 0 && y < snapToEdgeThreshold) {
         return constants.isAndroid
           ? this.setState(
-              {
-                isFolded: false
-              },
-              scrollNode.scrollTo({ x: 0, y: 0, animated: true })
-            )
+            {
+              isFolded: false
+            },
+            scrollNode.getNode().scrollTo({ x: 0, y: 0, animated: true })
+          )
           : timing(snapToEdgeAnimatedValue, {
-              toValue: { x: 0, y: 0 },
-              duration: 400,
-              easing: Easing.out(Easing.cubic),
-              useNativeDriver: true
-            }).start(() => {
-              snapToEdgeAnimatedValue.removeListener(id)
-              this.setState({
-                isFolded: false
-              })
+            toValue: { x: 0, y: 0 },
+            duration: 400,
+            easing: Easing.out(Easing.cubic),
+            useNativeDriver: true
+          }).start(() => {
+            snapToEdgeAnimatedValue.removeListener(id)
+            this.setState({
+              isFolded: false
             })
+          })
       }
       if (y >= snapToEdgeThreshold && y < scrollHeight) {
         return constants.isAndroid
           ? this.setState(
-              {
-                isFolded: true
-              },
-              scrollNode.scrollTo({ x: 0, y: scrollHeight, animated: true })
-            )
+            {
+              isFolded: true
+            },
+            scrollNode.getNode().scrollTo({ x: 0, y: scrollHeight, animated: true })
+          )
           : timing(snapToEdgeAnimatedValue, {
-              toValue: { x: 0, y: snap },
-              duration: 400,
-              easing: Easing.out(Easing.cubic),
-              useNativeDriver: true
-            }).start(() => {
-              snapToEdgeAnimatedValue.removeListener(id)
-              this.setState({
-                isFolded: true
-              })
+            toValue: { x: 0, y: snap },
+            duration: 400,
+            easing: Easing.out(Easing.cubic),
+            useNativeDriver: true
+          }).start(() => {
+            snapToEdgeAnimatedValue.removeListener(id)
+            this.setState({
+              isFolded: true
             })
+          })
       }
     }
 
@@ -157,7 +157,7 @@ class StickyParallaxHeader extends Component {
       })
     }
     if (this.scrollView) {
-      this.scrollView.scrollTo({
+      this.scrollView.getNode().scrollTo({
         x: offset,
         y: 0,
         animated: true
@@ -194,7 +194,7 @@ class StickyParallaxHeader extends Component {
             backgroundColor: isArray
               ? arrayHeaderStyle.backgroundColor
               : backgroundColor || headerStyle?.backgroundColor,
-            ...( transparentHeader && styles.transparentHeader )
+            ...(transparentHeader && styles.transparentHeader)
           })
         }
       >
@@ -248,7 +248,7 @@ class StickyParallaxHeader extends Component {
         style={{
           height: backgroundHeight,
           backgroundColor: tabsContainerBackgroundColor,
-          ...( backgroundImage && styles.transparentBackground )
+          ...(backgroundImage && styles.transparentBackground)
         }}
       >
         {foreground}
@@ -413,9 +413,9 @@ StickyParallaxHeader.propTypes = {
   tabsContainerBackgroundColor: string,
   tabWrapperStyle: ViewPropTypes.style,
   tabsContainerStyle: ViewPropTypes.style,
-  snapStartThreshold: oneOfType([ bool, number]),
-  snapStopThreshold: oneOfType([ bool, number]),
-  snapValue: oneOfType([ bool, number]),
+  snapStartThreshold: oneOfType([bool, number]),
+  snapStopThreshold: oneOfType([bool, number]),
+  snapValue: oneOfType([bool, number]),
   transparentHeader: bool
 }
 

--- a/src/components/ScrollableTabBar/ScrollableTabBar.js
+++ b/src/components/ScrollableTabBar/ScrollableTabBar.js
@@ -83,7 +83,8 @@ class ScrollableTabBar extends React.PureComponent {
       tabTextContainerActiveStyle,
       tabsContainerBackgroundColor,
       tabWrapperStyle,
-      tabsContainerStyle
+      tabsContainerStyle,
+      fixedTabCount //jkl
     } = this.props
     const { tabUnderlineWidth } = this.state
 
@@ -130,14 +131,14 @@ class ScrollableTabBar extends React.PureComponent {
               <TouchableOpacity
                 key={tab.title}
                 accessible
-                style={tabWrapperStyle}
+                style={[tabWrapperStyle, fixedTabCount && styles.tabWrapperFixedTabCount]} //jkl
                 accessibilityLabel={tab.title}
                 accessibilityTraits="button"
                 activeOpacity={0.9}
                 onPress={() => this.goToPage(page)}
               >
                 <View style={[styles.tabContainer, tabTextContainerStyle, isTabActive && tabTextContainerActiveStyle]}>
-                  <Text
+                  {tab.title ? <Text
                     // eslint-disable-next-line no-return-assign
                     onLayout={({
                       nativeEvent: {
@@ -153,7 +154,7 @@ class ScrollableTabBar extends React.PureComponent {
                     style={[styles.tabText, tabTextStyle, isTabActive && tabTextActiveStyle]}
                   >
                     {tab.title}
-                  </Text>
+                  </Text> : tab.icon}
                 </View>
               </TouchableOpacity>
             )

--- a/src/components/ScrollableTabBar/ScrollableTabBar.styles.js
+++ b/src/components/ScrollableTabBar/ScrollableTabBar.styles.js
@@ -7,7 +7,8 @@ export default StyleSheet.create({
   },
   contentContainer: {
     alignItems: 'center',
-    paddingHorizontal: 20
+    paddingHorizontal: 20,
+    width: '100%' //jkl
   },
   tabContainer: {
     alignItems: 'center',
@@ -24,6 +25,10 @@ export default StyleSheet.create({
     fontSize: 16
   },
   nestedStyle: {
-    alignSelf: 'center'
+    alignSelf: 'center',
+    width: '100%' //jkl
+  },
+  tabWrapperFixedTabCount: {
+    flex: 1
   }
 })

--- a/src/predefinedComponents/TabbedHeader/TabbedHeader.js
+++ b/src/predefinedComponents/TabbedHeader/TabbedHeader.js
@@ -105,10 +105,10 @@ export default class TabbedHeader extends React.Component {
 
     const renderImage = () => {
       const logo = isUndefined(foregroundImage)
-      ? require('../../assets/images/photosPortraitMe.png')
-      : foregroundImage
+        ? require('../../assets/images/photosPortraitMe.png')
+        : foregroundImage
 
-      if(foregroundImage !== null){
+      if (foregroundImage !== null) {
         return (
           <Animated.View style={{ opacity: imageOpacity }}>
             <Animated.Image
@@ -175,7 +175,8 @@ export default class TabbedHeader extends React.Component {
       tabTextContainerStyle,
       tabTextContainerActiveStyle,
       tabWrapperStyle,
-      tabsContainerStyle
+      tabsContainerStyle,
+      fixedTabCount //jkl
     } = this.props
 
     return (
@@ -186,7 +187,7 @@ export default class TabbedHeader extends React.Component {
           header={this.renderHeader()}
           deviceWidth={constants.deviceWidth}
           parallaxHeight={sizes.homeScreenParallaxHeader}
-          scrollEvent={event([{ nativeEvent: { contentOffset: { y: this.scrollY.y } } }], {useNativeDriver: false, listener: e => scrollEvent && scrollEvent(e)})}
+          scrollEvent={event([{ nativeEvent: { contentOffset: { y: this.scrollY.y } } }], { useNativeDriver: false, listener: e => scrollEvent && scrollEvent(e) })}
           headerSize={this.setHeaderSize}
           headerHeight={headerHeight}
           tabs={tabs}
@@ -200,6 +201,7 @@ export default class TabbedHeader extends React.Component {
           bounces={bounces}
           snapToEdge={snapToEdge}
           tabsContainerStyle={tabsContainerStyle}
+          fixedTabCount={fixedTabCount} // jkl
         >
           {renderBody('Popular Quizes')}
         </StickyParallaxHeader>
@@ -230,14 +232,15 @@ TabbedHeader.propTypes = {
   tabsContainerStyle: ViewPropTypes.style,
   foregroundImage: Image.propTypes.source,
   titleStyle: Text.propTypes.style,
-  header: func
+  header: func,
+  fixedTabCount: bool //jkl
 }
 
 TabbedHeader.defaultProps = {
   backgroundColor: colors.primaryGreen,
   headerHeight: sizes.headerHeight,
   backgroundImage: null,
-  title: "Mornin' Mark! \nReady for a quiz?",
+  title: "Mornin' Chris! \nReady for a quizz?",
   bounces: true,
   snapToEdge: true,
   logo: require('../../assets/images/logo.png'),
@@ -267,5 +270,6 @@ TabbedHeader.defaultProps = {
   tabTextActiveStyle: styles.tabText,
   tabTextContainerStyle: styles.tabTextContainerStyle,
   tabTextContainerActiveStyle: styles.tabTextContainerActiveStyle,
-  tabWrapperStyle: styles.tabsWrapper
+  tabWrapperStyle: styles.tabsWrapper,
+  fixedTabCount: false // jkl
 }


### PR DESCRIPTION
I replaced every occurrence of `scrollTo()` with `getNode().scrollTo()` in **StickyParallaxHeader.js**.