### PR TITLE
fix: fixed issue with scrollNode

### DIFF
--- a/src/StickyParallaxHeader.js
+++ b/src/StickyParallaxHeader.js
@@ -1,24 +1,6 @@
 import React, { Component } from 'react'
-import {
-  arrayOf,
-  bool,
-  func,
-  node,
-  number,
-  shape,
-  string,
-  oneOfType
-} from 'prop-types'
-import {
-  Dimensions,
-  ImageBackground,
-  ScrollView,
-  View,
-  Animated,
-  Easing,
-  ViewPropTypes,
-  Image
-} from 'react-native'
+import { arrayOf, bool, func, node, number, shape, string, oneOfType } from 'prop-types'
+import { Dimensions, ImageBackground, ScrollView, View, Animated, Easing, ViewPropTypes, Image } from 'react-native'
 import { ScrollableTabBar, ScrollableTabView } from './components'
 import { constants } from './constants'
 import styles from './styles'
@@ -56,7 +38,7 @@ class StickyParallaxHeader extends Component {
   }
 
   spring = () => {
-    const scrollNode = this.scroll
+    const scrollNode = this.scroll && this.scroll.scrollTo ? this.scroll : this.scroll.getNode()
     scrollNode.scrollTo({ x: 0, y: 40, animated: true })
 
     return setTimeout(() => {
@@ -72,7 +54,7 @@ class StickyParallaxHeader extends Component {
     const scrollHeight = snapStopThreshold || height
     const snap = snapValue || height
     const { snapToEdge } = this.props
-    const scrollNode = this.scroll
+    const scrollNode = this.scroll && this.scroll.scrollTo ? this.scroll : this.scroll.getNode()
     // eslint-disable-next-line no-underscore-dangle
     const scrollValue = this.scrollY.__getValue()
     const { y } = scrollValue
@@ -194,7 +176,7 @@ class StickyParallaxHeader extends Component {
             backgroundColor: isArray
               ? arrayHeaderStyle.backgroundColor
               : backgroundColor || headerStyle?.backgroundColor,
-            ...( transparentHeader && styles.transparentHeader )
+            ...(transparentHeader && styles.transparentHeader)
           })
         }
       >
@@ -248,7 +230,7 @@ class StickyParallaxHeader extends Component {
         style={{
           height: backgroundHeight,
           backgroundColor: tabsContainerBackgroundColor,
-          ...( backgroundImage && styles.transparentBackground )
+          ...(backgroundImage && styles.transparentBackground)
         }}
       >
         {foreground}
@@ -413,9 +395,9 @@ StickyParallaxHeader.propTypes = {
   tabsContainerBackgroundColor: string,
   tabWrapperStyle: ViewPropTypes.style,
   tabsContainerStyle: ViewPropTypes.style,
-  snapStartThreshold: oneOfType([ bool, number]),
-  snapStopThreshold: oneOfType([ bool, number]),
-  snapValue: oneOfType([ bool, number]),
+  snapStartThreshold: oneOfType([bool, number]),
+  snapStopThreshold: oneOfType([bool, number]),
+  snapValue: oneOfType([bool, number]),
   transparentHeader: bool
 }
 

--- a/src/StickyParallaxHeader.js
+++ b/src/StickyParallaxHeader.js
@@ -4,6 +4,7 @@ import { Dimensions, ImageBackground, ScrollView, View, Animated, Easing, ViewPr
 import { ScrollableTabBar, ScrollableTabView } from './components'
 import { constants } from './constants'
 import styles from './styles'
+import { getSafelyScrollNode } from './utils'
 
 const { divide, Value, createAnimatedComponent, event, timing, ValueXY } = Animated
 const AnimatedScrollView = createAnimatedComponent(ScrollView)
@@ -38,7 +39,7 @@ class StickyParallaxHeader extends Component {
   }
 
   spring = () => {
-    const scrollNode = this.scroll && this.scroll.scrollTo ? this.scroll : this.scroll.getNode()
+    const scrollNode = getSafelyScrollNode(this.scroll)
     scrollNode.scrollTo({ x: 0, y: 40, animated: true })
 
     return setTimeout(() => {
@@ -54,7 +55,8 @@ class StickyParallaxHeader extends Component {
     const scrollHeight = snapStopThreshold || height
     const snap = snapValue || height
     const { snapToEdge } = this.props
-    const scrollNode = this.scroll && this.scroll.scrollTo ? this.scroll : this.scroll.getNode()
+
+    const scrollNode = getSafelyScrollNode(this.scroll)
     // eslint-disable-next-line no-underscore-dangle
     const scrollValue = this.scrollY.__getValue()
     const { y } = scrollValue

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,10 +6,7 @@ export function isIphoneX() {
     Platform.OS === 'ios' &&
     !Platform.isPad &&
     !Platform.isTVOS &&
-    (dimen.height === 812 ||
-      dimen.width === 812 ||
-      dimen.height === 896 ||
-      dimen.width === 896)
+    (dimen.height === 812 || dimen.width === 812 || dimen.height === 896 || dimen.width === 896)
   )
 }
 
@@ -18,4 +15,12 @@ export function ifIphoneX(iphoneXStyle, regularStyle) {
     return iphoneXStyle
   }
   return regularStyle
+}
+
+export function getSafelyScrollNode(scrollNode) {
+  // after react-native 0.62
+  if (scrollNode && scrollNode.scrollTo) return scrollNode
+
+  // before react-native 0.62
+  return scrollNode.getNode()
 }


### PR DESCRIPTION
### Description

scrollNode.scrollTo was previously undefined when running sticky parallax header on Expo SDK lower than 38.

### Solution

I've added suggested solution after testing it on Expo SDK 37.

Issue: https://github.com/netguru/sticky-parallax-header/issues/102