### PR TITLE
fix: changed all images propTypes to Image.propTypes.source

### DIFF
--- a/src/predefinedComponents/AvatarHeader/AvatarHeader.js
+++ b/src/predefinedComponents/AvatarHeader/AvatarHeader.js
@@ -159,10 +159,10 @@ class AvatarHeader extends React.Component {
     const { backgroundColor, hasBorderRadius } = this.props
 
     const headerBorderRadius = this.scrollY.y.interpolate({
-        inputRange: [0, height],
-        outputRange: [80, 0],
-        extrapolate: 'extend'
-      })
+      inputRange: [0, height],
+      outputRange: [80, 0],
+      extrapolate: 'extend'
+    })
 
     const borderBottomRightRadius = hasBorderRadius ? headerBorderRadius : 0
 
@@ -235,18 +235,18 @@ AvatarHeader.propTypes = {
   rightTopIcon: number,
   backgroundColor: string,
   headerHeight: number,
-  backgroundImage: number,
+  backgroundImage: Image.propTypes.source,
   title: string,
   subtitle: string,
-  image: number,
+  image: Image.propTypes.source,
   renderBody: func,
   scrollEvent: func,
   parallaxHeight: number,
   foreground: func,
   header: func,
-  snapStartThreshold: oneOfType([ bool, number]),
-  snapStopThreshold: oneOfType([ bool, number]),
-  snapValue: oneOfType([ bool, number]),
+  snapStartThreshold: oneOfType([bool, number]),
+  snapStopThreshold: oneOfType([bool, number]),
+  snapValue: oneOfType([bool, number]),
   transparentHeader: bool
 }
 AvatarHeader.defaultProps = {

--- a/src/predefinedComponents/DetailsHeader/DetailsHeader.js
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeader.js
@@ -130,14 +130,14 @@ class DetailsHeader extends React.Component {
     const { backgroundColor, backgroundImage, renderBody, headerHeight, snapToEdge, bounces } = this.props
 
     return (
-      <React.Fragment>
+      <>
         <StatusBar barStyle="light-content" backgroundColor={backgroundColor} translucent />
         <StickyParallaxHeader
           foreground={this.renderForeground(user)}
           header={this.renderHeader(user)}
           deviceWidth={constants.deviceWidth}
           parallaxHeight={sizes.cardScreenParallaxHeader}
-          scrollEvent={event([{ nativeEvent: { contentOffset: { y: this.scrollY.y } } }], {useNativeDriver: false})}
+          scrollEvent={event([{ nativeEvent: { contentOffset: { y: this.scrollY.y } } }], { useNativeDriver: false })}
           headerSize={this.setHeaderSize}
           headerHeight={headerHeight}
           background={this.renderBackground(user)}
@@ -147,7 +147,7 @@ class DetailsHeader extends React.Component {
         >
           {renderBody(user)}
         </StickyParallaxHeader>
-      </React.Fragment>
+      </>
     )
   }
 }
@@ -159,10 +159,10 @@ DetailsHeader.propTypes = {
   rightTopIcon: number,
   backgroundColor: string,
   headerHeight: number,
-  backgroundImage: number,
+  backgroundImage: Image.propTypes.source,
   title: string,
   tag: string,
-  image: number,
+  image: Image.propTypes.source,
   renderBody: func,
   bounces: bool,
   snapToEdge: bool,

--- a/src/predefinedComponents/TabbedHeader/TabbedHeader.js
+++ b/src/predefinedComponents/TabbedHeader/TabbedHeader.js
@@ -1,20 +1,6 @@
 import React from 'react'
-import {
-  Text,
-  View,
-  Image,
-  StatusBar,
-  Animated,
-  ViewPropTypes
-} from 'react-native'
-import {
-  arrayOf,
-  bool,
-  number,
-  shape,
-  string,
-  func
-} from 'prop-types'
+import { Text, View, Image, StatusBar, Animated, ViewPropTypes } from 'react-native'
+import { arrayOf, bool, number, shape, string, func } from 'prop-types'
 import StickyParallaxHeader from '../../index'
 import { constants, colors, sizes } from '../../constants'
 import styles from './TabbedHeader.styles'
@@ -53,21 +39,11 @@ export default class TabbedHeader extends React.Component {
   }
 
   renderLogoHeader = () => {
-    const {
-      backgroundColor,
-      logo,
-      logoResizeMode,
-      logoStyle,
-      logoContainerStyle
-    } = this.props
+    const { backgroundColor, logo, logoResizeMode, logoStyle, logoContainerStyle } = this.props
 
     return (
       <View style={[logoContainerStyle, { backgroundColor }]}>
-        <Image
-          resizeMode={logoResizeMode}
-          source={logo}
-          style={logoStyle}
-        />
+        <Image resizeMode={logoResizeMode} source={logo} style={logoStyle} />
       </View>
     )
   }
@@ -104,17 +80,12 @@ export default class TabbedHeader extends React.Component {
     })
 
     const renderImage = () => {
-      const logo = isUndefined(foregroundImage)
-      ? require('../../assets/images/photosPortraitMe.png')
-      : foregroundImage
+      const logo = isUndefined(foregroundImage) ? require('../../assets/images/photosPortraitMe.png') : foregroundImage
 
-      if(foregroundImage !== null){
+      if (foregroundImage !== null) {
         return (
           <Animated.View style={{ opacity: imageOpacity }}>
-            <Animated.Image
-              source={logo}
-              style={[styles.profilePic, { width: imageSize, height: imageSize }]}
-            />
+            <Animated.Image source={logo} style={[styles.profilePic, { width: imageSize, height: imageSize }]} />
           </Animated.View>
         )
       }
@@ -186,7 +157,10 @@ export default class TabbedHeader extends React.Component {
           header={this.renderHeader()}
           deviceWidth={constants.deviceWidth}
           parallaxHeight={sizes.homeScreenParallaxHeader}
-          scrollEvent={event([{ nativeEvent: { contentOffset: { y: this.scrollY.y } } }], {useNativeDriver: false, listener: e => scrollEvent && scrollEvent(e)})}
+          scrollEvent={event([{ nativeEvent: { contentOffset: { y: this.scrollY.y } } }], {
+            useNativeDriver: false,
+            listener: (e) => scrollEvent && scrollEvent(e)
+          })}
           headerSize={this.setHeaderSize}
           headerHeight={headerHeight}
           tabs={tabs}
@@ -217,7 +191,7 @@ TabbedHeader.propTypes = {
   snapToEdge: bool,
   tabs: arrayOf(shape({})),
   renderBody: func,
-  logo: number,
+  logo: Image.propTypes.source,
   logoResizeMode: string,
   logoStyle: ViewPropTypes.style,
   logoContainerStyle: ViewPropTypes.style,
@@ -241,10 +215,10 @@ TabbedHeader.defaultProps = {
   bounces: true,
   snapToEdge: true,
   logo: require('../../assets/images/logo.png'),
-  logoResizeMode: "contain",
+  logoResizeMode: 'contain',
   logoStyle: styles.logo,
   logoContainerStyle: styles.headerWrapper,
-  renderBody: title => <RenderContent title={title} />,
+  renderBody: (title) => <RenderContent title={title} />,
   tabs: [
     {
       title: 'Popular',


### PR DESCRIPTION
### Description

Image prop types were set to number. I've changed them to Image.propTypes.source, so users can now pass their images without errors.

To pass image with uri you can do it like that:

`      <StickyParallaxHeader
        headerType="AvatarHeader"
        image={{uri: http://example.com/image.jpg}} />`

Issue: #107 