### PR TITLE
fix: fixed scrollNode issue inside ScrollableTabView

### DIFF
--- a/src/components/ScrollableTabView/ScrollableTabView.js
+++ b/src/components/ScrollableTabView/ScrollableTabView.js
@@ -4,6 +4,7 @@ import { Animated, StyleSheet, View } from 'react-native'
 import { func, node, number, shape, bool } from 'prop-types'
 import SceneComponent from './SceneComponent'
 import constants from '../../constants/constants'
+import { getSafelyScrollNode } from '../../utils'
 
 const styles = StyleSheet.create({
   container: {
@@ -78,10 +79,10 @@ class ScrollableTabView extends React.Component {
 
   scrollToTop = () => {
     const { scrollRef, scrollHeight, isHeaderFolded } = this.props
-
+    const scrollNode = getSafelyScrollNode(scrollRef)
     return (
       isHeaderFolded &&
-      scrollRef.scrollTo({
+      scrollNode.scrollTo({
         y: scrollHeight,
         duration: 1000
       })
@@ -166,8 +167,9 @@ class ScrollableTabView extends React.Component {
   goToPage = (pageNumber) => {
     const { containerWidth } = this.state
     const offset = pageNumber * containerWidth
-    if (this.scrollView) {
-      this.scrollView.scrollTo({ x: offset, y: 0, animated: true })
+    const scrollNode = getSafelyScrollNode(this.scrollView);
+    if (scrollNode) {
+      scrollNode.scrollTo({ x: offset, y: 0, animated: true })
     }
 
     const { currentPage } = this.state

--- a/src/components/ScrollableTabView/ScrollableTabView.js
+++ b/src/components/ScrollableTabView/ScrollableTabView.js
@@ -81,7 +81,7 @@ class ScrollableTabView extends React.Component {
     const { scrollRef, scrollHeight, isHeaderFolded } = this.props
     const scrollNode = getSafelyScrollNode(scrollRef)
     return (
-      isHeaderFolded &&
+      isHeaderFolded && scrollNode &&
       scrollNode.scrollTo({
         y: scrollHeight,
         duration: 1000


### PR DESCRIPTION
### Description

scrollTo was still undefined on ScrollableTabView. Fixed it by using method from utils, previously used inside StickyParallaxHeader.js

Issue: #102