### PR TITLE
#63 #92 Content is scrollable when one tab is longer

### DIFF
--- a/src/StickyParallaxHeader.js
+++ b/src/StickyParallaxHeader.js
@@ -44,6 +44,20 @@ class StickyParallaxHeader extends Component {
     this.props.onRef?.(this)
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    const { headerHeight, parallaxHeight, tabs } = this.props
+    const { currentPage, isFolded } = this.state
+    const isRenderingTabs = tabs && tabs.length > 0
+
+    if (isRenderingTabs && prevState.currentPage !== currentPage && isFolded) {
+      const scrollHeight = Math.max(parallaxHeight, headerHeight * 2)
+      setTimeout(() => {
+        const scrollNode = getSafelyScrollNode(this.scroll)
+        scrollNode.scrollTo({ y: scrollHeight, duration: 1000 })
+      }, 250)
+    }
+  }
+
   componentWillUnmount() {
     this.scrollY.removeAllListeners()
     this.props.onRef?.(null)
@@ -303,6 +317,9 @@ class StickyParallaxHeader extends Component {
       headerStyle.map((el) => Object.assign(arrayHeaderStyle, el))
     }
 
+    const scrollViewMinHeight = Dimensions.get('window').height + parallaxHeight - headerHeight
+    const innerScrollHeight = Dimensions.get('window').height - headerHeight - parallaxHeight
+
     const shouldRenderTabs = tabs && tabs.length > 0
 
     return (
@@ -317,6 +334,7 @@ class StickyParallaxHeader extends Component {
           ref={(c) => {
             this.scroll = c
           }}
+          contentContainerStyle={{ minHeight: scrollViewMinHeight }}
           onScrollEndDrag={() => this.onScrollEndSnapToEdge(scrollHeight)}
           scrollEventThrottle={1}
           stickyHeaderIndices={shouldRenderTabs ? [1] : []}
@@ -366,6 +384,7 @@ class StickyParallaxHeader extends Component {
             scrollRef={this.scroll}
             scrollHeight={scrollHeight}
             isHeaderFolded={isFolded}
+            minScrollHeight={innerScrollHeight}
           >
             {!tabs && children}
             {tabs &&

--- a/src/StickyParallaxHeader.js
+++ b/src/StickyParallaxHeader.js
@@ -46,10 +46,11 @@ class StickyParallaxHeader extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     const { headerHeight, parallaxHeight, tabs } = this.props
+    const prevPage = prevState.currentPage
     const { currentPage, isFolded } = this.state
     const isRenderingTabs = tabs && tabs.length > 0
 
-    if (isRenderingTabs && prevState.currentPage !== currentPage && isFolded) {
+    if (isRenderingTabs && prevPage !== currentPage && isFolded) {
       const scrollHeight = Math.max(parallaxHeight, headerHeight * 2)
       setTimeout(() => {
         const scrollNode = getSafelyScrollNode(this.scroll)

--- a/src/components/ScrollableTabView/ScrollableTabView.js
+++ b/src/components/ScrollableTabView/ScrollableTabView.js
@@ -92,16 +92,17 @@ class ScrollableTabView extends React.Component {
     this.children().map((child, idx) => {
       const key = this.makeSceneKey(child, idx)
       const { currentPage, containerWidth, sceneKeys } = this.state
-      const {minViewportHeight } = this.props
+      const { minScrollHeight } = this.props
 
       return (
         <SceneComponent
           key={child.key}
           shouldUpdated={this.shouldRenderSceneKey(idx, currentPage)}
+          /* eslint-disable-next-line react-native/no-inline-styles */
           style={{
             width: containerWidth,
-            minHeight: minViewportHeight,
-            maxHeight: idx === currentPage ? null : minViewportHeight
+            minHeight: minScrollHeight,
+            maxHeight: idx === currentPage ? null : minScrollHeight
           }}
         >
           {this.keyExists(sceneKeys, key) ? child : null}

--- a/src/components/ScrollableTabView/ScrollableTabView.js
+++ b/src/components/ScrollableTabView/ScrollableTabView.js
@@ -77,18 +77,6 @@ class ScrollableTabView extends React.Component {
     })
   }
 
-  scrollToTop = () => {
-    const { scrollRef, scrollHeight, isHeaderFolded } = this.props
-    const scrollNode = getSafelyScrollNode(scrollRef)
-    return (
-      isHeaderFolded && scrollNode &&
-      scrollNode.scrollTo({
-        y: scrollHeight,
-        duration: 1000
-      })
-    )
-  }
-
   updateSelectedPage = (nextPage) => {
     let localNextPage = nextPage
     if (typeof localNextPage === 'object') {
@@ -104,12 +92,17 @@ class ScrollableTabView extends React.Component {
     this.children().map((child, idx) => {
       const key = this.makeSceneKey(child, idx)
       const { currentPage, containerWidth, sceneKeys } = this.state
+      const {minViewportHeight } = this.props
 
       return (
         <SceneComponent
           key={child.key}
           shouldUpdated={this.shouldRenderSceneKey(idx, currentPage)}
-          style={{ width: containerWidth }}
+          style={{
+            width: containerWidth,
+            minHeight: minViewportHeight,
+            maxHeight: idx === currentPage ? null : minViewportHeight
+          }}
         >
           {this.keyExists(sceneKeys, key) ? child : null}
         </SceneComponent>
@@ -177,8 +170,6 @@ class ScrollableTabView extends React.Component {
       page: pageNumber,
       callback: this.onChangeTab.bind(this, currentPage, pageNumber)
     })
-
-    this.scrollToTop()
   }
 
   onScroll = (e) => {
@@ -208,11 +199,13 @@ class ScrollableTabView extends React.Component {
     const scenes = this.composeScenes()
     const { initialPage } = this.props
     const { containerWidth, scrollXIOS } = this.state
+    const { minScrollHeight } = this.props
 
     return (
       <Animated.ScrollView
         horizontal
         pagingEnabled
+        contentContainerStyle={{ minHeight: minScrollHeight }}
         automaticallyAdjustContentInsets={false}
         contentOffset={{ x: initialPage * containerWidth }}
         ref={(scrollView) => {
@@ -252,6 +245,7 @@ ScrollableTabView.propTypes = {
   onChangeTab: func,
   swipedPage: func,
   scrollHeight: number,
+  minScrollHeight: number,
   isHeaderFolded: bool,
   scrollRef: shape({})
 }


### PR DESCRIPTION
### Description

- Removed scrollToTop from ScrollableTabView
- Added scrollToTop in componentDidUpdate to StickyParallaxHeader
- Added minHeight to tab containers and webviews
- Added maxHeight equal to full container height to inactive tab