### PR TITLE
#160 Prevent rerender of background Image on tab change

### DIFF
--- a/src/StickyParallaxHeader.js
+++ b/src/StickyParallaxHeader.js
@@ -29,6 +29,35 @@ import { getSafelyScrollNode, setRef } from './utils';
 const { divide, Value, createAnimatedComponent, event, timing, ValueXY } = Animated;
 const AnimatedScrollView = createAnimatedComponent(ScrollView);
 
+const HeaderBackgroundImage = (props) => {
+  const { backgroundHeight, backgroundImage, background } = props;
+  const AnimatedImageBackground = createAnimatedComponent(ImageBackground);
+
+  return (
+    <AnimatedImageBackground
+      style={[
+        styles.headerStyle,
+        {
+          height: backgroundHeight,
+        },
+      ]}
+      source={backgroundImage}>
+      {background}
+    </AnimatedImageBackground>
+  );
+};
+
+HeaderBackgroundImage.propTypes = {
+  background: node,
+  backgroundHeight: number,
+  backgroundImage: Image.propTypes.source,
+};
+
+const headerImagesAreEqual = (prevProps, props) =>
+  prevProps.backgroundImage.uri === props.backgroundImage.uri;
+
+const MemoHeaderImageBackground = React.memo(HeaderBackgroundImage, headerImagesAreEqual);
+
 class StickyParallaxHeader extends Component {
   constructor(props) {
     super(props);
@@ -240,25 +269,6 @@ class StickyParallaxHeader extends Component {
     );
   };
 
-  renderImageBackground = (backgroundHeight) => {
-    const { backgroundImage, background } = this.props;
-
-    const AnimatedImageBackground = createAnimatedComponent(ImageBackground);
-
-    return (
-      <AnimatedImageBackground
-        style={[
-          styles.headerStyle,
-          {
-            height: backgroundHeight,
-          },
-        ]}
-        source={backgroundImage}>
-        {background}
-      </AnimatedImageBackground>
-    );
-  };
-
   renderPlainBackground = (backgroundHeight) => {
     const { background } = this.props;
 
@@ -405,9 +415,15 @@ class StickyParallaxHeader extends Component {
                 },
               ]}
             />
-            {backgroundImage
-              ? this.renderImageBackground(scrollHeight)
-              : this.renderPlainBackground(scrollHeight)}
+            {backgroundImage ? (
+              <MemoHeaderImageBackground
+                backgroundHeight={scrollHeight}
+                backgroundImage={this.props.backgroundImage}
+                background={this.props.background}
+              />
+            ) : (
+              this.renderPlainBackground(scrollHeight)
+            )}
             {this.renderForeground(scrollHeight)}
           </View>
           {shouldRenderTabs && this.renderTabs()}

--- a/src/StickyParallaxHeader.js
+++ b/src/StickyParallaxHeader.js
@@ -11,52 +11,14 @@ import {
   instanceOf,
   element,
 } from 'prop-types';
-import {
-  Dimensions,
-  ImageBackground,
-  ScrollView,
-  View,
-  Animated,
-  Easing,
-  ViewPropTypes,
-  Image,
-} from 'react-native';
-import { ScrollableTabBar, ScrollableTabView } from './components';
+import { Dimensions, ScrollView, View, Animated, Easing, ViewPropTypes, Image } from 'react-native';
+import { ScrollableTabBar, ScrollableTabView, HeaderBackgroundImage } from './components';
 import { constants } from './constants';
 import styles from './styles';
 import { getSafelyScrollNode, setRef } from './utils';
 
 const { divide, Value, createAnimatedComponent, event, timing, ValueXY } = Animated;
 const AnimatedScrollView = createAnimatedComponent(ScrollView);
-
-const HeaderBackgroundImage = (props) => {
-  const { backgroundHeight, backgroundImage, background } = props;
-  const AnimatedImageBackground = createAnimatedComponent(ImageBackground);
-
-  return (
-    <AnimatedImageBackground
-      style={[
-        styles.headerStyle,
-        {
-          height: backgroundHeight,
-        },
-      ]}
-      source={backgroundImage}>
-      {background}
-    </AnimatedImageBackground>
-  );
-};
-
-HeaderBackgroundImage.propTypes = {
-  background: node,
-  backgroundHeight: number,
-  backgroundImage: Image.propTypes.source,
-};
-
-const headerImagesAreEqual = (prevProps, props) =>
-  prevProps.backgroundImage.uri === props.backgroundImage.uri;
-
-const MemoHeaderImageBackground = React.memo(HeaderBackgroundImage, headerImagesAreEqual);
 
 class StickyParallaxHeader extends Component {
   constructor(props) {
@@ -333,6 +295,7 @@ class StickyParallaxHeader extends Component {
 
   render() {
     const {
+      background,
       backgroundImage,
       children,
       contentContainerStyles,
@@ -416,10 +379,10 @@ class StickyParallaxHeader extends Component {
               ]}
             />
             {backgroundImage ? (
-              <MemoHeaderImageBackground
+              <HeaderBackgroundImage
                 backgroundHeight={scrollHeight}
-                backgroundImage={this.props.backgroundImage}
-                background={this.props.background}
+                backgroundImage={backgroundImage}
+                background={background}
               />
             ) : (
               this.renderPlainBackground(scrollHeight)

--- a/src/components/HeaderBackgroundImage/HeaderBackgroundImage.js
+++ b/src/components/HeaderBackgroundImage/HeaderBackgroundImage.js
@@ -30,7 +30,9 @@ HeaderBackgroundImage.propTypes = {
 };
 
 const headerImagesAreEqual = (prevProps, props) =>
-  prevProps.backgroundImage.uri === props.backgroundImage.uri;
+  prevProps.backgroundImage.uri === props.backgroundImage.uri &&
+  prevProps.backgroundHeight === props.backgroundHeight &&
+  prevProps.background === props.background;
 
 const MemoHeaderBackgroundImage = React.memo(HeaderBackgroundImage, headerImagesAreEqual);
 

--- a/src/components/HeaderBackgroundImage/HeaderBackgroundImage.js
+++ b/src/components/HeaderBackgroundImage/HeaderBackgroundImage.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { node, number } from 'prop-types';
+import { ImageBackground, Animated, Image } from 'react-native';
+import styles from './HeaderBackgroundImage.styles';
+
+const { createAnimatedComponent } = Animated;
+
+const HeaderBackgroundImage = (props) => {
+  const { backgroundHeight, backgroundImage, background } = props;
+  const AnimatedImageBackground = createAnimatedComponent(ImageBackground);
+
+  return (
+    <AnimatedImageBackground
+      style={[
+        styles.headerStyle,
+        {
+          height: backgroundHeight,
+        },
+      ]}
+      source={backgroundImage}>
+      {background}
+    </AnimatedImageBackground>
+  );
+};
+
+HeaderBackgroundImage.propTypes = {
+  background: node,
+  backgroundHeight: number,
+  backgroundImage: Image.propTypes.source,
+};
+
+const headerImagesAreEqual = (prevProps, props) =>
+  prevProps.backgroundImage.uri === props.backgroundImage.uri;
+
+const MemoHeaderBackgroundImage = React.memo(HeaderBackgroundImage, headerImagesAreEqual);
+
+export default MemoHeaderBackgroundImage;

--- a/src/components/HeaderBackgroundImage/HeaderBackgroundImage.styles.js
+++ b/src/components/HeaderBackgroundImage/HeaderBackgroundImage.styles.js
@@ -1,0 +1,17 @@
+import { StyleSheet, Dimensions } from 'react-native';
+
+const { width } = Dimensions.get('window');
+
+const styles = StyleSheet.create({
+  headerStyle: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: width + 0.5,
+    justifyContent: 'flex-end',
+    marginBottom: 5,
+    paddingBottom: 3,
+  },
+});
+
+export default styles;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,5 @@
 import ScrollableTabBar from './ScrollableTabBar/ScrollableTabBar';
 import ScrollableTabView from './ScrollableTabView/ScrollableTabView';
+import HeaderBackgroundImage from './HeaderBackgroundImage/HeaderBackgroundImage';
 
-export { ScrollableTabBar, ScrollableTabView };
+export { ScrollableTabBar, ScrollableTabView, HeaderBackgroundImage };


### PR DESCRIPTION
fixes: #160 

**Note**: Could I get the `hacktoberfest-accepted` label on this PR if everything looks ok? 

I edited the example to show that the background image will still re render if the source uri changes by showing a different background image on refresh
![Large GIF (378x758)](https://user-images.githubusercontent.com/9373516/97084027-17249e00-15e2-11eb-8391-02dae3cf91bf.gif)

