### PR TITLE
Update default decelerationRate to normal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sticky-parallax-header",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "source": "src/index",

--- a/src/StickyParallaxHeader.js
+++ b/src/StickyParallaxHeader.js
@@ -363,7 +363,7 @@ class StickyParallaxHeader extends Component {
           overScrollMode="never"
           refreshControl={refreshControl}
           bouncesZoom
-          decelerationRate="fast"
+          decelerationRate="normal"
           nestedScrollEnabled
           ref={(c) => {
             this.scroll = c;

--- a/src/components/ScrollableTabView/ScrollableTabView.js
+++ b/src/components/ScrollableTabView/ScrollableTabView.js
@@ -211,8 +211,6 @@ class ScrollableTabView extends React.Component {
         keyboardShouldPersistTaps={keyboardShouldPersistTaps}
         horizontal
         pagingEnabled
-        bounces={false}
-        nestedScrollEnabled={true}
         contentContainerStyle={{ minHeight: minScrollHeight }}
         automaticallyAdjustContentInsets={false}
         contentOffset={{ x: initialPage * containerWidth }}

--- a/src/components/ScrollableTabView/ScrollableTabView.js
+++ b/src/components/ScrollableTabView/ScrollableTabView.js
@@ -211,6 +211,7 @@ class ScrollableTabView extends React.Component {
         keyboardShouldPersistTaps={keyboardShouldPersistTaps}
         horizontal
         pagingEnabled
+        bounces={false}
         contentContainerStyle={{ minHeight: minScrollHeight }}
         automaticallyAdjustContentInsets={false}
         contentOffset={{ x: initialPage * containerWidth }}

--- a/src/components/ScrollableTabView/ScrollableTabView.js
+++ b/src/components/ScrollableTabView/ScrollableTabView.js
@@ -212,6 +212,7 @@ class ScrollableTabView extends React.Component {
         horizontal
         pagingEnabled
         bounces={false}
+        nestedScrollEnabled={true}
         contentContainerStyle={{ minHeight: minScrollHeight }}
         automaticallyAdjustContentInsets={false}
         contentOffset={{ x: initialPage * containerWidth }}


### PR DESCRIPTION
Changing the `decelerationRate` of `AnimatedScrollView` inside `StickyParallalHeader.js` to `normal` for more user friendly scrolling experience on longer item lists. I realize there is another PR in the works for adding a `decelerationRate` prop but this one should be an easy merge and something i think most people would enjoy. Fast deceleration is way too difficult to scroll on any paginated list (I have a FlatList of posts inside the ScrollView).