### PR TITLE
Missing shared props in predefined headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Below are examples of those components and description of the props they are acc
 | `keyboardShouldPersistTaps`   | `'always', 'never', 'handled', false, true`           |    Yes   | `undefined`                                                                                                                                                                                    | Determines when the keyboard should stay visible after a tap.|
 | `refreshControl`              | `RefreshControl`           |    Yes   | `undefined`                                                                                                                                                                                    | Props used to add pull to refresh functionality.|
 |     `decelerationRate`      |             `number or string`              |   Yes    |                    `"fast"`                     |                                     Set the deceleration rate for the ScrollView. 
+| `parallaxHeight`      | `number`                                                   |    No    | -                                                                            | Set parallax header height                               |
+| `foreground`          | `() => ReactElement`                                       |    No    | -                                                                            | Function that renders the foreground of the header       |
+| `headerSize`          | `func`                                                     |    Yes   | -                                                                            | Get current size of header                               |
 
 ### Details Header, Avatar Header
 
@@ -131,6 +134,7 @@ Below are examples of those components and description of the props they are acc
  | `iconNumber`          | `number`                          |    No    | `10`                                                                         | Set amount of cards shown on icon                        |
 | `tag`                 | `string`                          |    No    | `"Product Designer"`                                                         | Sets header tag name                                     |
 | `title`               | `string`                          |    No    | `"Design System"`                                                            | Sets header title                                        |
+| `transparentHeader`   | `boolean`                                                  |    No    | `false`                                                                      | Set header transparency to render custom header          |
 
 
 ## Avatar Header
@@ -139,9 +143,7 @@ Below are examples of those components and description of the props they are acc
 
 | Property              | Type                                                       | Optional |  Default                                                                     | Description                                              |
 | :-------------------: | :---------------------------------------------------------:| :-------:| :---------------------------------------------------------------------------:| :-------------------------------------------------------:|
- | `foreground`          | `() => ReactElement`                                       |    No    | -                                                                            | Function that renders the foreground of the header       |
 | `header`              | `() => ReactElement`                                       |    No    | -                                                                            | Function that renders custom header                      |
-| `parallaxHeight`      | `number`                                                   |    No    | -                                                                            | Set parallax header height                               |
  | `scrollEvent`         | `(event: NativeSyntheticEvent<NativeScrollEvent>) => void` |    No    | `require('../../assets/icons/Icon-Menu.png') `                               | Scroll event to apply custom animations                  |
 | `snapStartThreshold`  | `number`                                                   |    No    | -                                                                            | Set start value Threshold of snap                        |
  | `snapStopThreshold`   | `number`                                                   |    No    | -                                                                            | Set stop value Threshold of snap                         |

--- a/src/StickyParallaxHeader.js
+++ b/src/StickyParallaxHeader.js
@@ -310,6 +310,8 @@ class StickyParallaxHeader extends Component {
       scrollRef,
       refreshControl,
       decelerationRate,
+      onMomentumScrollEnd,
+      onMomentumScrollBegin,
     } = this.props;
     const { currentPage, isFolded } = this.state;
     const scrollHeight = Math.max(parallaxHeight, headerHeight * 2);
@@ -352,6 +354,8 @@ class StickyParallaxHeader extends Component {
           stickyHeaderIndices={shouldRenderTabs ? [1] : []}
           showsVerticalScrollIndicator={false}
           keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+          onMomentumScrollEnd={onMomentumScrollEnd}
+          onMomentumScrollBegin={onMomentumScrollBegin}
           onScroll={event(
             [
               {
@@ -462,6 +466,8 @@ StickyParallaxHeader.propTypes = {
   scrollRef: oneOfType([func, shape({ current: instanceOf(ScrollView) })]),
   keyboardShouldPersistTaps: oneOf(['never', 'always', 'handled', false, true, undefined]),
   refreshControl: element,
+  onMomentumScrollEnd: func, 
+  onMomentumScrollBegin: func,
 };
 
 StickyParallaxHeader.defaultProps = {
@@ -487,6 +493,8 @@ StickyParallaxHeader.defaultProps = {
   keyboardShouldPersistTaps: undefined,
   refreshControl: undefined,
   decelerationRate: "fast",
+  onMomentumScrollEnd: undefined, 
+  onMomentumScrollBegin: undefined,
 };
 
 export default StickyParallaxHeader;

--- a/src/StickyParallaxHeader.js
+++ b/src/StickyParallaxHeader.js
@@ -42,9 +42,10 @@ class StickyParallaxHeader extends Component {
   }
 
   componentDidMount() {
+    const { onRef } = this.props;
     // eslint-disable-next-line
     this.scrollY.addListener(({ value }) => (this._value = value));
-    this.props.onRef?.(this);
+    onRef?.(this);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -466,8 +467,9 @@ StickyParallaxHeader.propTypes = {
   scrollRef: oneOfType([func, shape({ current: instanceOf(ScrollView) })]),
   keyboardShouldPersistTaps: oneOf(['never', 'always', 'handled', false, true, undefined]),
   refreshControl: element,
-  onMomentumScrollEnd: func, 
+  onMomentumScrollEnd: func,
   onMomentumScrollBegin: func,
+  decelerationRate: oneOf(['fast', 'normal']),
 };
 
 StickyParallaxHeader.defaultProps = {
@@ -492,8 +494,8 @@ StickyParallaxHeader.defaultProps = {
   scrollRef: null,
   keyboardShouldPersistTaps: undefined,
   refreshControl: undefined,
-  decelerationRate: "fast",
-  onMomentumScrollEnd: undefined, 
+  decelerationRate: 'fast',
+  onMomentumScrollEnd: undefined,
   onMomentumScrollBegin: undefined,
 };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,7 +43,6 @@ export interface SharedProps {
   decelerationRate: number | string;
   children?: ReactElement;
   parallaxHeight?: number;
-  transparentHeader?: boolean;
   foreground?: () => ReactElement;
   headerSize?: (headerSizeProps: HeaderSizeProps) => void;
 }
@@ -93,6 +92,7 @@ export type DetailsHeaderProps = SharedProps &
     renderBody?: (title: string) => ReactElement;
     tag?: string;
     title?: string;
+    transparentHeader?: boolean;
   };
 
 export type AvatarHeaderProps = SharedProps &
@@ -109,6 +109,7 @@ export type AvatarHeaderProps = SharedProps &
     snapValue?: number;
     subtitle?: string;
     title?: string;
+    transparentHeader?: boolean;
   };
 
 export type CustomHeaderProps = SharedProps &

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,6 +43,7 @@ export interface SharedProps {
   decelerationRate: number | string;
   children?: ReactElement;
   parallaxHeight?: number;
+  transparentHeader?: boolean;
 }
 
 export interface IconProps {
@@ -106,7 +107,6 @@ export type AvatarHeaderProps = SharedProps &
     snapValue?: number;
     subtitle?: string;
     title?: string;
-    transparentHeader?: boolean;
   };
 
 export type CustomHeaderProps = SharedProps &
@@ -126,7 +126,6 @@ export type CustomHeaderProps = SharedProps &
     snapStopThreshold?: number;
     snapValue?: number;
     tabsContainerBackgroundColor?: string;
-    transparentHeader?: boolean;
   };
 
 type StickyParallaxHeaderProps = HeaderTypeProp &

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -45,6 +45,7 @@ export interface SharedProps {
   parallaxHeight?: number;
   transparentHeader?: boolean;
   foreground?: () => ReactElement;
+  headerSize?: (headerSizeProps: HeaderSizeProps) => void;
 }
 
 export interface IconProps {
@@ -64,7 +65,8 @@ export interface TabsSharedProps {
   tabsContainerStyle?: ViewStyle;
 }
 
-export type TabbedHeaderProps = HeaderTypeProp & SharedProps &
+export type TabbedHeaderProps = HeaderTypeProp &
+  SharedProps &
   TabsSharedProps & {
     headerType: 'TabbedHeader';
     backgroundColor?: string;
@@ -116,7 +118,6 @@ export type CustomHeaderProps = SharedProps &
     backgroundColor: string;
     children?: ReactElement;
     header: ReactElement;
-    headerSize?: (headerSizeProps: HeaderSizeProps) => void;
     initialPage?: number;
     onChangeTab?: (changeTabArguments: OnChangeTabArguments) => void;
     onEndReached?: () => void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -44,6 +44,7 @@ export interface SharedProps {
   children?: ReactElement;
   parallaxHeight?: number;
   transparentHeader?: boolean;
+  foreground?: () => ReactElement;
 }
 
 export interface IconProps {
@@ -96,7 +97,6 @@ export type AvatarHeaderProps = SharedProps &
   IconProps & {
     headerType: 'AvatarHeader';
     backgroundColor?: string;
-    foreground?: () => ReactElement;
     hasBorderRadius?: boolean;
     header?: () => ReactElement;
     image?: number;
@@ -115,7 +115,6 @@ export type CustomHeaderProps = SharedProps &
     background: ReactElement;
     backgroundColor: string;
     children?: ReactElement;
-    foreground?: ReactElement;
     header: ReactElement;
     headerSize?: (headerSizeProps: HeaderSizeProps) => void;
     initialPage?: number;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,6 +42,7 @@ export interface SharedProps {
   refreshControl?: ReactElement;
   decelerationRate: number | string;
   children?: ReactElement;
+  parallaxHeight?: number;
 }
 
 export interface IconProps {
@@ -98,7 +99,6 @@ export type AvatarHeaderProps = SharedProps &
     hasBorderRadius?: boolean;
     header?: () => ReactElement;
     image?: number;
-    parallaxHeight?: number;
     renderBody?: (title: string) => ReactElement;
     scrollEvent?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
     snapStartThreshold?: number;
@@ -121,7 +121,6 @@ export type CustomHeaderProps = SharedProps &
     initialPage?: number;
     onChangeTab?: (changeTabArguments: OnChangeTabArguments) => void;
     onEndReached?: () => void;
-    parallaxHeight?: number;
     scrollEvent?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
     snapStartThreshold?: number;
     snapStopThreshold?: number;

--- a/src/predefinedComponents/AvatarHeader/AvatarHeader.js
+++ b/src/predefinedComponents/AvatarHeader/AvatarHeader.js
@@ -218,6 +218,8 @@ class AvatarHeader extends React.Component {
       scrollRef,
       keyboardShouldPersistTaps,
       refreshControl,
+      onMomentumScrollEnd,
+      onMomentumScrollBegin,
     } = this.props;
 
     if (renderBody) {
@@ -249,7 +251,9 @@ class AvatarHeader extends React.Component {
           snapValue={snapValue}
           scrollRef={scrollRef}
           keyboardShouldPersistTaps={keyboardShouldPersistTaps}
-          refreshControl={refreshControl}>
+          refreshControl={refreshControl}
+          onMomentumScrollEnd={onMomentumScrollEnd} 
+          onMomentumScrollBegin={onMomentumScrollBegin}>
           {renderBody ? renderBody() : children}
         </StickyParallaxHeader>
       </>
@@ -285,7 +289,9 @@ AvatarHeader.propTypes = {
   scrollRef: oneOfType([func, shape({ current: instanceOf(ScrollView) })]),
   keyboardShouldPersistTaps: oneOf(['never', 'always', 'handled', false, true, undefined]),
   refreshControl: element,
-  headerSize: func
+  headerSize: func,
+  onMomentumScrollEnd: func, 
+  onMomentumScrollBegin: func,
 };
 AvatarHeader.defaultProps = {
   leftTopIconOnPress: () => {},
@@ -308,7 +314,9 @@ AvatarHeader.defaultProps = {
   scrollRef: null,
   keyboardShouldPersistTaps: undefined,
   refreshControl: undefined,
-  headerSize: undefined
+  headerSize: undefined,
+  onMomentumScrollEnd: undefined, 
+  onMomentumScrollBegin: undefined,
 };
 
 export default AvatarHeader;

--- a/src/predefinedComponents/AvatarHeader/AvatarHeader.js
+++ b/src/predefinedComponents/AvatarHeader/AvatarHeader.js
@@ -24,7 +24,13 @@ class AvatarHeader extends React.Component {
     this.scrollY = new ValueXY();
   }
 
-  setHeaderSize = (headerLayout) => this.setState({ headerLayout });
+  setHeaderSize = (headerLayout) => {
+    const {
+      headerSize
+    } = this.props;
+    if (headerSize) headerSize(headerLayout)
+    this.setState({ headerLayout });
+  }
 
   scrollPosition(value) {
     const {
@@ -279,6 +285,7 @@ AvatarHeader.propTypes = {
   scrollRef: oneOfType([func, shape({ current: instanceOf(ScrollView) })]),
   keyboardShouldPersistTaps: oneOf(['never', 'always', 'handled', false, true, undefined]),
   refreshControl: element,
+  headerSize: func
 };
 AvatarHeader.defaultProps = {
   leftTopIconOnPress: () => {},
@@ -301,6 +308,7 @@ AvatarHeader.defaultProps = {
   scrollRef: null,
   keyboardShouldPersistTaps: undefined,
   refreshControl: undefined,
+  headerSize: undefined
 };
 
 export default AvatarHeader;

--- a/src/predefinedComponents/AvatarHeader/AvatarHeader.js
+++ b/src/predefinedComponents/AvatarHeader/AvatarHeader.js
@@ -1,6 +1,26 @@
 import React from 'react';
-import { Text, View, Image, TouchableOpacity, Animated, StatusBar, ViewPropTypes, ScrollView } from 'react-native';
-import { func, string, number, bool, oneOfType, oneOf, instanceOf, element, shape, node } from 'prop-types';
+import {
+  Text,
+  View,
+  Image,
+  TouchableOpacity,
+  Animated,
+  StatusBar,
+  ViewPropTypes,
+  ScrollView,
+} from 'react-native';
+import {
+  func,
+  string,
+  number,
+  bool,
+  oneOfType,
+  oneOf,
+  instanceOf,
+  element,
+  shape,
+  node,
+} from 'prop-types';
 import StickyParallaxHeader from '../../StickyParallaxHeader';
 import { constants, sizes } from '../../constants';
 import styles from './AvatarHeader.styles';
@@ -25,12 +45,10 @@ class AvatarHeader extends React.Component {
   }
 
   setHeaderSize = (headerLayout) => {
-    const {
-      headerSize
-    } = this.props;
-    if (headerSize) headerSize(headerLayout)
+    const { headerSize } = this.props;
+    if (headerSize) headerSize(headerLayout);
     this.setState({ headerLayout });
-  }
+  };
 
   scrollPosition(value) {
     const {
@@ -252,7 +270,7 @@ class AvatarHeader extends React.Component {
           scrollRef={scrollRef}
           keyboardShouldPersistTaps={keyboardShouldPersistTaps}
           refreshControl={refreshControl}
-          onMomentumScrollEnd={onMomentumScrollEnd} 
+          onMomentumScrollEnd={onMomentumScrollEnd}
           onMomentumScrollBegin={onMomentumScrollBegin}>
           {renderBody ? renderBody() : children}
         </StickyParallaxHeader>
@@ -290,7 +308,7 @@ AvatarHeader.propTypes = {
   keyboardShouldPersistTaps: oneOf(['never', 'always', 'handled', false, true, undefined]),
   refreshControl: element,
   headerSize: func,
-  onMomentumScrollEnd: func, 
+  onMomentumScrollEnd: func,
   onMomentumScrollBegin: func,
 };
 AvatarHeader.defaultProps = {
@@ -315,7 +333,7 @@ AvatarHeader.defaultProps = {
   keyboardShouldPersistTaps: undefined,
   refreshControl: undefined,
   headerSize: undefined,
-  onMomentumScrollEnd: undefined, 
+  onMomentumScrollEnd: undefined,
   onMomentumScrollBegin: undefined,
 };
 

--- a/src/predefinedComponents/DetailsHeader/DetailsHeader.js
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeader.js
@@ -60,7 +60,7 @@ class DetailsHeader extends React.Component {
     );
   };
 
-  renderForeground = (user) => {
+  renderDetailsForeground = (user) => () => {
     const { labelColor } = user;
     const { image, title, tag, iconNumber } = this.props;
     const labelOpacity = this.scrollY.y.interpolate({
@@ -105,6 +105,13 @@ class DetailsHeader extends React.Component {
     );
   };
 
+  renderForeground = (user) => {
+    const { foreground } = this.props;
+    const renderForeground = foreground || this.renderDetailsForeground(user);
+
+    return renderForeground(user);
+  };
+
   renderBackground = () => {
     const { hasBorderRadius, backgroundColor } = this.props;
     const {
@@ -142,7 +149,7 @@ class DetailsHeader extends React.Component {
       snapToEdge,
       bounces,
       parallaxHeight,
-      transparentHeader
+      transparentHeader,
     } = this.props;
 
     if (renderBody) {
@@ -193,6 +200,7 @@ DetailsHeader.propTypes = {
   iconNumber: number,
   parallaxHeight: number,
   transparentHeader: bool,
+  foreground: func
 };
 DetailsHeader.defaultProps = {
   leftTopIconOnPress: () => {},

--- a/src/predefinedComponents/DetailsHeader/DetailsHeader.js
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeader.js
@@ -141,6 +141,7 @@ class DetailsHeader extends React.Component {
       headerHeight,
       snapToEdge,
       bounces,
+      parallaxHeight
     } = this.props;
 
     if (renderBody) {
@@ -154,7 +155,7 @@ class DetailsHeader extends React.Component {
           foreground={this.renderForeground(user)}
           header={this.renderHeader(user)}
           deviceWidth={constants.deviceWidth}
-          parallaxHeight={sizes.cardScreenParallaxHeader}
+          parallaxHeight={parallaxHeight}
           scrollEvent={event([{ nativeEvent: { contentOffset: { y: this.scrollY.y } } }], {
             useNativeDriver: false,
           })}
@@ -188,6 +189,7 @@ DetailsHeader.propTypes = {
   snapToEdge: bool,
   hasBorderRadius: bool,
   iconNumber: number,
+  parallaxHeight: number
 };
 DetailsHeader.defaultProps = {
   leftTopIconOnPress: () => {},
@@ -205,6 +207,7 @@ DetailsHeader.defaultProps = {
   snapToEdge: true,
   hasBorderRadius: true,
   iconNumber: Brandon.cardsAmount,
+  parallaxHeight: sizes.cardScreenParallaxHeader
 };
 
 export default DetailsHeader;

--- a/src/predefinedComponents/DetailsHeader/DetailsHeader.js
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeader.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text, View, Image, TouchableOpacity, StatusBar, Animated, ScrollView } from 'react-native';
-import { bool, number, func, string, node } from 'prop-types';
+import { bool, number, func, string, node, oneOfType, shape, instanceOf } from 'prop-types';
 import StickyParallaxHeader from '../../StickyParallaxHeader';
 import { constants, sizes } from '../../constants';
 import { Brandon } from '../../assets/data/cards';

--- a/src/predefinedComponents/DetailsHeader/DetailsHeader.js
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeader.js
@@ -21,12 +21,10 @@ class DetailsHeader extends React.Component {
   }
 
   setHeaderSize = (headerLayout) => {
-    const {
-      headerSize
-    } = this.props;
-    if (headerSize) headerSize(headerLayout)
+    const { headerSize } = this.props;
+    if (headerSize) headerSize(headerLayout);
     this.setState({ headerLayout });
-  }
+  };
 
   scrollPosition = (value) => {
     const { headerLayout } = this.state;
@@ -158,7 +156,7 @@ class DetailsHeader extends React.Component {
       transparentHeader,
       onMomentumScrollEnd,
       onMomentumScrollBegin,
-      scrollRef
+      scrollRef,
     } = this.props;
 
     if (renderBody) {
@@ -184,7 +182,7 @@ class DetailsHeader extends React.Component {
           backgroundImage={backgroundImage}
           transparentHeader={transparentHeader}
           scrollRef={scrollRef}
-          onMomentumScrollEnd={onMomentumScrollEnd} 
+          onMomentumScrollEnd={onMomentumScrollEnd}
           onMomentumScrollBegin={onMomentumScrollBegin}>
           {renderBody ? renderBody() : children}
         </StickyParallaxHeader>
@@ -215,7 +213,7 @@ DetailsHeader.propTypes = {
   foreground: func,
   headerSize: func,
   scrollRef: oneOfType([func, shape({ current: instanceOf(ScrollView) })]),
-  onMomentumScrollEnd: func, 
+  onMomentumScrollEnd: func,
   onMomentumScrollBegin: func,
 };
 DetailsHeader.defaultProps = {
@@ -238,7 +236,7 @@ DetailsHeader.defaultProps = {
   transparentHeader: false,
   headerSize: undefined,
   scrollRef: null,
-  onMomentumScrollEnd: undefined, 
+  onMomentumScrollEnd: undefined,
   onMomentumScrollBegin: undefined,
 };
 

--- a/src/predefinedComponents/DetailsHeader/DetailsHeader.js
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeader.js
@@ -156,6 +156,9 @@ class DetailsHeader extends React.Component {
       bounces,
       parallaxHeight,
       transparentHeader,
+      onMomentumScrollEnd,
+      onMomentumScrollBegin,
+      scrollRef
     } = this.props;
 
     if (renderBody) {
@@ -180,7 +183,9 @@ class DetailsHeader extends React.Component {
           bounces={bounces}
           backgroundImage={backgroundImage}
           transparentHeader={transparentHeader}
-          scrollRef={scrollRef}>
+          scrollRef={scrollRef}
+          onMomentumScrollEnd={onMomentumScrollEnd} 
+          onMomentumScrollBegin={onMomentumScrollBegin}>
           {renderBody ? renderBody() : children}
         </StickyParallaxHeader>
       </>
@@ -210,6 +215,8 @@ DetailsHeader.propTypes = {
   foreground: func,
   headerSize: func,
   scrollRef: oneOfType([func, shape({ current: instanceOf(ScrollView) })]),
+  onMomentumScrollEnd: func, 
+  onMomentumScrollBegin: func,
 };
 DetailsHeader.defaultProps = {
   leftTopIconOnPress: () => {},
@@ -231,6 +238,8 @@ DetailsHeader.defaultProps = {
   transparentHeader: false,
   headerSize: undefined,
   scrollRef: null,
+  onMomentumScrollEnd: undefined, 
+  onMomentumScrollBegin: undefined,
 };
 
 export default DetailsHeader;

--- a/src/predefinedComponents/DetailsHeader/DetailsHeader.js
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeader.js
@@ -20,7 +20,13 @@ class DetailsHeader extends React.Component {
     this.scrollY = new ValueXY();
   }
 
-  setHeaderSize = (headerLayout) => this.setState({ headerLayout });
+  setHeaderSize = (headerLayout) => {
+    const {
+      headerSize
+    } = this.props;
+    if (headerSize) headerSize(headerLayout)
+    this.setState({ headerLayout });
+  }
 
   scrollPosition = (value) => {
     const { headerLayout } = this.state;
@@ -200,7 +206,8 @@ DetailsHeader.propTypes = {
   iconNumber: number,
   parallaxHeight: number,
   transparentHeader: bool,
-  foreground: func
+  foreground: func,
+  headerSize: func
 };
 DetailsHeader.defaultProps = {
   leftTopIconOnPress: () => {},
@@ -219,7 +226,8 @@ DetailsHeader.defaultProps = {
   hasBorderRadius: true,
   iconNumber: Brandon.cardsAmount,
   parallaxHeight: sizes.cardScreenParallaxHeader,
-  transparentHeader: false
+  transparentHeader: false,
+  headerSize: undefined
 };
 
 export default DetailsHeader;

--- a/src/predefinedComponents/DetailsHeader/DetailsHeader.js
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeader.js
@@ -141,7 +141,8 @@ class DetailsHeader extends React.Component {
       headerHeight,
       snapToEdge,
       bounces,
-      parallaxHeight
+      parallaxHeight,
+      transparentHeader
     } = this.props;
 
     if (renderBody) {
@@ -164,7 +165,8 @@ class DetailsHeader extends React.Component {
           background={this.renderBackground(user)}
           snapToEdge={snapToEdge}
           bounces={bounces}
-          backgroundImage={backgroundImage}>
+          backgroundImage={backgroundImage}
+          transparentHeader={transparentHeader}>
           {renderBody ? renderBody() : children}
         </StickyParallaxHeader>
       </>
@@ -189,7 +191,8 @@ DetailsHeader.propTypes = {
   snapToEdge: bool,
   hasBorderRadius: bool,
   iconNumber: number,
-  parallaxHeight: number
+  parallaxHeight: number,
+  transparentHeader: bool,
 };
 DetailsHeader.defaultProps = {
   leftTopIconOnPress: () => {},
@@ -207,7 +210,8 @@ DetailsHeader.defaultProps = {
   snapToEdge: true,
   hasBorderRadius: true,
   iconNumber: Brandon.cardsAmount,
-  parallaxHeight: sizes.cardScreenParallaxHeader
+  parallaxHeight: sizes.cardScreenParallaxHeader,
+  transparentHeader: false
 };
 
 export default DetailsHeader;

--- a/src/predefinedComponents/DetailsHeader/DetailsHeader.js
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeader.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, View, Image, TouchableOpacity, StatusBar, Animated } from 'react-native';
+import { Text, View, Image, TouchableOpacity, StatusBar, Animated, ScrollView } from 'react-native';
 import { bool, number, func, string, node } from 'prop-types';
 import StickyParallaxHeader from '../../StickyParallaxHeader';
 import { constants, sizes } from '../../constants';
@@ -179,7 +179,8 @@ class DetailsHeader extends React.Component {
           snapToEdge={snapToEdge}
           bounces={bounces}
           backgroundImage={backgroundImage}
-          transparentHeader={transparentHeader}>
+          transparentHeader={transparentHeader}
+          scrollRef={scrollRef}>
           {renderBody ? renderBody() : children}
         </StickyParallaxHeader>
       </>
@@ -207,7 +208,8 @@ DetailsHeader.propTypes = {
   parallaxHeight: number,
   transparentHeader: bool,
   foreground: func,
-  headerSize: func
+  headerSize: func,
+  scrollRef: oneOfType([func, shape({ current: instanceOf(ScrollView) })]),
 };
 DetailsHeader.defaultProps = {
   leftTopIconOnPress: () => {},
@@ -227,7 +229,8 @@ DetailsHeader.defaultProps = {
   iconNumber: Brandon.cardsAmount,
   parallaxHeight: sizes.cardScreenParallaxHeader,
   transparentHeader: false,
-  headerSize: undefined
+  headerSize: undefined,
+  scrollRef: null,
 };
 
 export default DetailsHeader;

--- a/src/predefinedComponents/TabbedHeader/TabbedHeader.js
+++ b/src/predefinedComponents/TabbedHeader/TabbedHeader.js
@@ -29,7 +29,13 @@ export default class TabbedHeader extends React.Component {
     this.scrollY.y.removeListener();
   }
 
-  setHeaderSize = (headerLayout) => this.setState({ headerLayout });
+  setHeaderSize = (headerLayout) => {
+    const {
+      headerSize
+    } = this.props;
+    if (headerSize) headerSize(headerLayout)
+    this.setState({ headerLayout });
+  }
 
   scrollPosition = (value) => {
     const { headerLayout } = this.state;
@@ -249,7 +255,8 @@ TabbedHeader.propTypes = {
   onRef: func,
   parallaxHeight: number,
   transparentHeader: bool,
-  foreground: func
+  foreground: func,
+  headerSize: func
 };
 
 TabbedHeader.defaultProps = {
@@ -294,5 +301,6 @@ TabbedHeader.defaultProps = {
   scrollRef: null,
   onRef: null,
   parallaxHeight: sizes.homeScreenParallaxHeader,
-  transparentHeader: false
+  transparentHeader: false,
+  headerSize: undefined
 };

--- a/src/predefinedComponents/TabbedHeader/TabbedHeader.js
+++ b/src/predefinedComponents/TabbedHeader/TabbedHeader.js
@@ -163,6 +163,7 @@ export default class TabbedHeader extends React.Component {
       contentContainerStyles,
       refreshControl,
       rememberTabScrollPosition,
+      parallaxHeight
     } = this.props;
 
     if (renderBody) {
@@ -181,7 +182,7 @@ export default class TabbedHeader extends React.Component {
           foreground={this.renderForeground(this.scrollY)}
           header={this.renderHeader()}
           deviceWidth={constants.deviceWidth}
-          parallaxHeight={sizes.homeScreenParallaxHeader}
+          parallaxHeight={parallaxHeight}
           scrollEvent={event([{ nativeEvent: { contentOffset: { y: this.scrollY.y } } }], {
             useNativeDriver: false,
             listener: (e) => scrollEvent && scrollEvent(e),
@@ -237,6 +238,7 @@ TabbedHeader.propTypes = {
   titleStyle: Text.propTypes.style,
   header: func,
   onRef: func,
+  parallaxHeight: number
 };
 
 TabbedHeader.defaultProps = {
@@ -280,4 +282,5 @@ TabbedHeader.defaultProps = {
   refreshControl: undefined,
   scrollRef: null,
   onRef: null,
+  parallaxHeight: sizes.homeScreenParallaxHeader
 };

--- a/src/predefinedComponents/TabbedHeader/TabbedHeader.js
+++ b/src/predefinedComponents/TabbedHeader/TabbedHeader.js
@@ -1,6 +1,18 @@
 import React from 'react';
 import { Text, View, Image, StatusBar, Animated, ViewPropTypes, ScrollView } from 'react-native';
-import { arrayOf, bool, number, shape, string, func, node, element, oneOfType, oneOf, instanceOf } from 'prop-types';
+import {
+  arrayOf,
+  bool,
+  number,
+  shape,
+  string,
+  func,
+  node,
+  element,
+  oneOfType,
+  oneOf,
+  instanceOf,
+} from 'prop-types';
 import StickyParallaxHeader from '../../StickyParallaxHeader';
 import { constants, colors, sizes } from '../../constants';
 import styles from './TabbedHeader.styles';
@@ -30,12 +42,10 @@ export default class TabbedHeader extends React.Component {
   }
 
   setHeaderSize = (headerLayout) => {
-    const {
-      headerSize
-    } = this.props;
-    if (headerSize) headerSize(headerLayout)
+    const { headerSize } = this.props;
+    if (headerSize) headerSize(headerLayout);
     this.setState({ headerLayout });
-  }
+  };
 
   scrollPosition = (value) => {
     const { headerLayout } = this.state;
@@ -218,7 +228,7 @@ export default class TabbedHeader extends React.Component {
           tabsContainerStyle={tabsContainerStyle}
           onRef={onRef}
           transparentHeader={transparentHeader}
-          onMomentumScrollEnd={onMomentumScrollEnd} 
+          onMomentumScrollEnd={onMomentumScrollEnd}
           onMomentumScrollBegin={onMomentumScrollBegin}>
           {renderBody ? renderBody() : children}
         </StickyParallaxHeader>
@@ -261,7 +271,7 @@ TabbedHeader.propTypes = {
   transparentHeader: bool,
   foreground: func,
   headerSize: func,
-  onMomentumScrollEnd: func, 
+  onMomentumScrollEnd: func,
   onMomentumScrollBegin: func,
 };
 
@@ -309,6 +319,6 @@ TabbedHeader.defaultProps = {
   parallaxHeight: sizes.homeScreenParallaxHeader,
   transparentHeader: false,
   headerSize: undefined,
-  onMomentumScrollEnd: undefined, 
+  onMomentumScrollEnd: undefined,
   onMomentumScrollBegin: undefined,
 };

--- a/src/predefinedComponents/TabbedHeader/TabbedHeader.js
+++ b/src/predefinedComponents/TabbedHeader/TabbedHeader.js
@@ -187,7 +187,6 @@ export default class TabbedHeader extends React.Component {
       refreshControl,
       rememberTabScrollPosition,
       parallaxHeight,
-      transparentHeader,
       onMomentumScrollEnd,
       onMomentumScrollBegin,
     } = this.props;
@@ -227,7 +226,6 @@ export default class TabbedHeader extends React.Component {
           snapToEdge={snapToEdge}
           tabsContainerStyle={tabsContainerStyle}
           onRef={onRef}
-          transparentHeader={transparentHeader}
           onMomentumScrollEnd={onMomentumScrollEnd}
           onMomentumScrollBegin={onMomentumScrollBegin}>
           {renderBody ? renderBody() : children}
@@ -268,7 +266,6 @@ TabbedHeader.propTypes = {
   header: func,
   onRef: func,
   parallaxHeight: number,
-  transparentHeader: bool,
   foreground: func,
   headerSize: func,
   onMomentumScrollEnd: func,
@@ -317,7 +314,6 @@ TabbedHeader.defaultProps = {
   scrollRef: null,
   onRef: null,
   parallaxHeight: sizes.homeScreenParallaxHeader,
-  transparentHeader: false,
   headerSize: undefined,
   onMomentumScrollEnd: undefined,
   onMomentumScrollBegin: undefined,

--- a/src/predefinedComponents/TabbedHeader/TabbedHeader.js
+++ b/src/predefinedComponents/TabbedHeader/TabbedHeader.js
@@ -177,7 +177,9 @@ export default class TabbedHeader extends React.Component {
       refreshControl,
       rememberTabScrollPosition,
       parallaxHeight,
-      transparentHeader
+      transparentHeader,
+      onMomentumScrollEnd,
+      onMomentumScrollBegin,
     } = this.props;
 
     if (renderBody) {
@@ -215,7 +217,9 @@ export default class TabbedHeader extends React.Component {
           snapToEdge={snapToEdge}
           tabsContainerStyle={tabsContainerStyle}
           onRef={onRef}
-          transparentHeader={transparentHeader}>
+          transparentHeader={transparentHeader}
+          onMomentumScrollEnd={onMomentumScrollEnd} 
+          onMomentumScrollBegin={onMomentumScrollBegin}>
           {renderBody ? renderBody() : children}
         </StickyParallaxHeader>
       </>
@@ -256,7 +260,9 @@ TabbedHeader.propTypes = {
   parallaxHeight: number,
   transparentHeader: bool,
   foreground: func,
-  headerSize: func
+  headerSize: func,
+  onMomentumScrollEnd: func, 
+  onMomentumScrollBegin: func,
 };
 
 TabbedHeader.defaultProps = {
@@ -302,5 +308,7 @@ TabbedHeader.defaultProps = {
   onRef: null,
   parallaxHeight: sizes.homeScreenParallaxHeader,
   transparentHeader: false,
-  headerSize: undefined
+  headerSize: undefined,
+  onMomentumScrollEnd: undefined, 
+  onMomentumScrollBegin: undefined,
 };

--- a/src/predefinedComponents/TabbedHeader/TabbedHeader.js
+++ b/src/predefinedComponents/TabbedHeader/TabbedHeader.js
@@ -200,7 +200,8 @@ export default class TabbedHeader extends React.Component {
           bounces={bounces}
           snapToEdge={snapToEdge}
           tabsContainerStyle={tabsContainerStyle}
-          onRef={onRef}>
+          onRef={onRef}
+          transparentHeader={transparentHeader}>
           {renderBody ? renderBody() : children}
         </StickyParallaxHeader>
       </>
@@ -238,7 +239,8 @@ TabbedHeader.propTypes = {
   titleStyle: Text.propTypes.style,
   header: func,
   onRef: func,
-  parallaxHeight: number
+  parallaxHeight: number,
+  transparentHeader: bool,
 };
 
 TabbedHeader.defaultProps = {
@@ -282,5 +284,6 @@ TabbedHeader.defaultProps = {
   refreshControl: undefined,
   scrollRef: null,
   onRef: null,
-  parallaxHeight: sizes.homeScreenParallaxHeader
+  parallaxHeight: sizes.homeScreenParallaxHeader,
+  transparentHeader: false
 };

--- a/src/predefinedComponents/TabbedHeader/TabbedHeader.js
+++ b/src/predefinedComponents/TabbedHeader/TabbedHeader.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text, View, Image, StatusBar, Animated, ViewPropTypes } from 'react-native';
+import { Text, View, Image, StatusBar, Animated, ViewPropTypes, ScrollView } from 'react-native';
 import { arrayOf, bool, number, shape, string, func, node, element, oneOfType, oneOf, instanceOf } from 'prop-types';
 import StickyParallaxHeader from '../../StickyParallaxHeader';
 import { constants, colors, sizes } from '../../constants';
@@ -54,7 +54,7 @@ export default class TabbedHeader extends React.Component {
     return renderHeader();
   };
 
-  renderForeground = (scrollY) => {
+  renderTabbedForeground = (scrollY) => () => {
     const { title, titleStyle, foregroundImage } = this.props;
     const messageStyle = titleStyle || styles.message;
     const startSize = constants.responsiveWidth(18);
@@ -107,6 +107,13 @@ export default class TabbedHeader extends React.Component {
         </Animated.View>
       </View>
     );
+  };
+
+  renderForeground = (scrollY) => {
+    const { foreground } = this.props;
+    const renderForeground = foreground || this.renderTabbedForeground(scrollY);
+
+    return renderForeground();
   };
 
   onLayoutContent = (e, title) => {
@@ -163,7 +170,8 @@ export default class TabbedHeader extends React.Component {
       contentContainerStyles,
       refreshControl,
       rememberTabScrollPosition,
-      parallaxHeight
+      parallaxHeight,
+      transparentHeader
     } = this.props;
 
     if (renderBody) {
@@ -241,6 +249,7 @@ TabbedHeader.propTypes = {
   onRef: func,
   parallaxHeight: number,
   transparentHeader: bool,
+  foreground: func
 };
 
 TabbedHeader.defaultProps = {


### PR DESCRIPTION
Adds missing shared props:
* foreground
* headerSize
* scrollRef
* onMomentumScrollEnd
* onMomentumScrollBegin

Adds missing props to the DetailsHeader:
* transparentHeader