### PR TITLE
fix: removing border radius causes crash on android

### DIFF
--- a/src/predefinedComponents/DetailsHeader/DetailsHeader.tsx
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeader.tsx
@@ -146,13 +146,13 @@ class DetailsHeader extends React.Component<DetailsHeaderProps, State> {
     const {
       headerLayout: { height },
     } = this.state;
-    const headerBorderRadius =
-      hasBorderRadius &&
-      this.scrollY.y.interpolate({
-        inputRange: [0, height],
-        outputRange: [80, 0],
-        extrapolate: 'extend',
-      });
+    const headerBorderRadius = hasBorderRadius
+      ? this.scrollY.y.interpolate({
+          inputRange: [0, height],
+          outputRange: [80, 0],
+          extrapolate: 'extend',
+        })
+      : 0;
 
     return (
       <Animated.View


### PR DESCRIPTION
Fixed boolean being passed to the borderBottomRightRadius prop, instead of number.