### PR TITLE
fix: npm package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "react-native": "src/index",
   "source": "src/index",
   "files": [
-    "assets",
     "src",
     "lib",
     "android",


### PR DESCRIPTION
**Description**

<!-- Describe, what this pull request is solving. -->

- remove assets folder from included files in npm package

**Affected platforms**

- [ ] Android
- [ ] iOS

**Test plan/screenshots/videos**

<!-- Demonstrate steps to check proposed changes. Add screenshots and/or videos if there are UI changes. -->

run `npm pack` before & after - size shrinks from (packaged/unpacked) 39.7MB/40.5MB to 110.6kB/794.3kB
