### PR TITLE
Change apt-get to brew

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -123,8 +123,8 @@ workflows:
                 #!/usr/bin/env bash
                 # fail if any commands fails
                 set -ex
-                apt-get update
-                apt-get install -y jq
+                brew update
+                brew install jq
                 result=$(curl -X GET "https://api.bitrise.io/v0.1/apps/${BITRISE_APP_SLUG}/builds/${BITRISE_BUILD_SLUG}/artifacts" -H "accept: application/json" -H "Authorization: ${BITRISE_ACCESS_TOKEN}" | jq -r .data[0].slug)
                 artifactSlug=$(curl -X GET "https://api.bitrise.io/v0.1/apps/${BITRISE_APP_SLUG}/builds/${BITRISE_BUILD_SLUG}/artifacts/${result}" -H "accept: application/json" -H "Authorization: ${BITRISE_ACCESS_TOKEN}" | jq -r .data.expiring_download_url)
                 export APPIUM_ARTIFACT_URL=${artifactSlug}


### PR DESCRIPTION
This pull request change apt-get to brew when installing "jq" in the Bitrise workflow.

**Description**

<!-- Describe, what this pull request is solving. -->

**Affected platforms**

- [ ] Android
- [ ] iOS

**Test plan/screenshots/videos**

<!-- Demonstrate steps to check proposed changes. Add screenshots and/or videos if there are UI changes. -->
