### PR TITLE
Fix name of samsung workflow from s7 to j7

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -130,7 +130,7 @@ workflows:
                 export APPIUM_ARTIFACT_URL=${artifactSlug}
                 echo "${APPIUM_ARTIFACT_URL}"
                 curl --location --request POST 'https://api.bitrise.io/v0.1/apps/a83b4e4adbd2a88d/builds' --header "Authorization: ${BITRISE_ACCESS_TOKEN}" --header 'Content-Type: application/json' --data-raw '{ "hook_info": { "type": "bitrise" }, "build_params": { "branch": "main", "workflow_id": "run_pixel_4", "environments": [{ "is_expand": true, "mapped_to": "APPIUM_ARTIFACT_URL", "value": "'"$APPIUM_ARTIFACT_URL"'" }]}}'
-                curl --location --request POST 'https://api.bitrise.io/v0.1/apps/a83b4e4adbd2a88d/builds' --header "Authorization: ${BITRISE_ACCESS_TOKEN}" --header 'Content-Type: application/json' --data-raw '{ "hook_info": { "type": "bitrise" }, "build_params": { "branch": "main", "workflow_id": "run_samsung_s7", "environments": [{ "is_expand": true, "mapped_to": "APPIUM_ARTIFACT_URL", "value": "'"$APPIUM_ARTIFACT_URL"'" }]}}'
+                curl --location --request POST 'https://api.bitrise.io/v0.1/apps/a83b4e4adbd2a88d/builds' --header "Authorization: ${BITRISE_ACCESS_TOKEN}" --header 'Content-Type: application/json' --data-raw '{ "hook_info": { "type": "bitrise" }, "build_params": { "branch": "main", "workflow_id": "run_samsung_j7", "environments": [{ "is_expand": true, "mapped_to": "APPIUM_ARTIFACT_URL", "value": "'"$APPIUM_ARTIFACT_URL"'" }]}}'
           title: Kick off appium tests
   prod_ios:
     description: >


### PR DESCRIPTION
This pull request resolves an issue that Appium tests are not launched for one device. Wrong name of the workflow.

**Description**

<!-- Describe, what this pull request is solving. -->

**Affected platforms**

- [ ] Android
- [ ] iOS

**Test plan/screenshots/videos**

<!-- Demonstrate steps to check proposed changes. Add screenshots and/or videos if there are UI changes. -->
