### PR TITLE
fix: react-18-compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Sticky Parallax Header ships with 3 different use cases for sticky headers and a
 This is how you can display header in your app:
 
 ```tsx
-import React from 'react'
+import * as React from 'react'
 import { DetailsHeaderScrollView } from 'react-native-sticky-parallax-header'
 
 const TestScreen = () => (

--- a/docs/docs/headers/avatar-header.md
+++ b/docs/docs/headers/avatar-header.md
@@ -9,7 +9,7 @@ sidebar_position: 4
 ## Example usage
 
 ```tsx
-import React from 'react'
+import * as React from 'react'
 import {
   AvatarHeaderScrollView,
   AvatarHeaderFlatList,

--- a/docs/docs/headers/custom-header.md
+++ b/docs/docs/headers/custom-header.md
@@ -7,7 +7,7 @@ sidebar_position: 5
 ## Example usage
 
 ```tsx
-import React from 'react';
+import * as React from 'react';
 import { View } from 'react-native';
 import {
   StickyHeaderScrollView,

--- a/docs/docs/headers/details-header.md
+++ b/docs/docs/headers/details-header.md
@@ -9,7 +9,7 @@ sidebar_position: 3
 ## Example usage
 
 ```tsx
-import React from 'react'
+import * as React from 'react'
 import {
   DetailsHeaderScrollView,
   DetailsHeaderFlatList,

--- a/docs/docs/headers/flashlist-headers.md
+++ b/docs/docs/headers/flashlist-headers.md
@@ -14,7 +14,7 @@ To make [FlashList](https://shopify.github.io/flash-list/docs/) work with react-
 
 ```tsx
 import { FlashList } from '@shopify/flash-list'
-import React from 'react'
+import * as React from 'react'
 import {
   withAvatarHeaderFlashList,
   withDetailsHeaderFlashList,

--- a/docs/docs/headers/tabbed-header-list.md
+++ b/docs/docs/headers/tabbed-header-list.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 ## Example usage
 
 ```tsx
-import React from 'react';
+import * as React from 'react';
 import { Text, View } from 'react-native';
 import { TabbedHeaderList } from 'react-native-sticky-parallax-header';
 

--- a/docs/docs/headers/tabbed-header-pager.md
+++ b/docs/docs/headers/tabbed-header-pager.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 ## Example usage
 
 ```tsx
-import React from 'react';
+import * as React from 'react';
 import { Text, View } from 'react-native';
 import { TabbedHeaderPager } from 'react-native-sticky-parallax-header';
 

--- a/docs/docs/introduction/getting-started.md
+++ b/docs/docs/introduction/getting-started.md
@@ -57,7 +57,7 @@ As with primitive components, FlashList can also be customized to create its own
 This is how you can display header in your app:
 
 ```tsx
-import React from 'react'
+import * as React from 'react'
 import { DetailsHeaderScrollView } from 'react-native-sticky-parallax-header'
 
 const TestScreen = () => (

--- a/docs/src/components/getStartedSection/GetStartedSection.tsx
+++ b/docs/src/components/getStartedSection/GetStartedSection.tsx
@@ -1,10 +1,9 @@
 import Link from '@docusaurus/Link';
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 
 import styles from './GetStartedSection.module.css';
 
-const GetStartedSection: FC = () => {
+const GetStartedSection: React.FC = () => {
   return (
     <section className={styles.wrapper}>
       <div className={styles.title}>Get started</div>

--- a/docs/src/components/homePageHeader/HomePageHeader.tsx
+++ b/docs/src/components/homePageHeader/HomePageHeader.tsx
@@ -2,12 +2,11 @@ import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import clsx from 'clsx';
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 
 import styles from './HomePageHeader.module.css';
 
-const HomePageHeader: FC = () => {
+const HomePageHeader: React.FC = () => {
   const { siteConfig } = useDocusaurusContext();
 
   return (

--- a/docs/src/components/sectionItem/SectionItem.tsx
+++ b/docs/src/components/sectionItem/SectionItem.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React from 'react';
+import * as React from 'react';
 
 import styles from './SectionItem.module.css';
 import { SectionItemContent } from './SectionItemContent';

--- a/docs/src/components/sectionItem/SectionItemContent.tsx
+++ b/docs/src/components/sectionItem/SectionItemContent.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 
 import styles from './SectionItem.module.css';
 
@@ -9,7 +8,7 @@ interface SectionItemContentProps {
   title: string;
 }
 
-export const SectionItemContent: FC<SectionItemContentProps> = ({ description, title }) => {
+export const SectionItemContent: React.FC<SectionItemContentProps> = ({ description, title }) => {
   return (
     <div className={clsx('col col--6', styles.contentWrapper)}>
       <div className={styles.content}>

--- a/docs/src/components/sectionItem/SectionItemImage.tsx
+++ b/docs/src/components/sectionItem/SectionItemImage.tsx
@@ -1,7 +1,6 @@
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import clsx from 'clsx';
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 
 import styles from './SectionItem.module.css';
 
@@ -10,7 +9,7 @@ interface SectionItemImageProps {
   imageName: string;
 }
 
-export const SectionItemImage: FC<SectionItemImageProps> = ({ imageName, index }) => {
+export const SectionItemImage: React.FC<SectionItemImageProps> = ({ imageName, index }) => {
   return (
     <div className={clsx('col col--6', styles.imageWrapper)}>
       <img

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,14 +1,13 @@
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 
 import GetStartedSection from '../components/getStartedSection/GetStartedSection';
 import HomePageHeader from '../components/homePageHeader/HomePageHeader';
 import SectionItem from '../components/sectionItem/SectionItem';
 import { SECTIONS_DATA } from '../data/sections';
 
-const Home: FC = () => {
+const Home: React.FC = () => {
   const { siteConfig } = useDocusaurusContext();
 
   return (

--- a/docs/versioned_docs/version-0.4.x/examples/custom-tabbed-header.md
+++ b/docs/versioned_docs/version-0.4.x/examples/custom-tabbed-header.md
@@ -196,7 +196,7 @@ const CutomHeaderScreen = () => {
 
 ## Summary - Full source code
 ```tsx
-import React from 'react'
+import * as React from 'react'
 import {
   Text,
   View,

--- a/docs/versioned_docs/version-0.4.x/headers/custom-header.md
+++ b/docs/versioned_docs/version-0.4.x/headers/custom-header.md
@@ -51,7 +51,7 @@ sidebar_position: 5
 Here is a basic example of how you can create a custom header
 
 ```jsx
-import React from 'react'
+import * as React from 'react'
 import { Text, View, Animated, StyleSheet } from 'react-native'
 import StickyParallaxHeader from 'react-native-sticky-parallax-header'
 const styles = StyleSheet.create({

--- a/docs/versioned_docs/version-0.4.x/introduction/getting-started.md
+++ b/docs/versioned_docs/version-0.4.x/introduction/getting-started.md
@@ -20,7 +20,7 @@ Predefined headers can be accessed through `headerType="HeaderName"` property, e
 This is how you can add them in your app:
 
 ```tsx
-import React from 'react'
+import * as React from 'react'
 import StickyParallaxHeader from 'react-native-sticky-parallax-header'
 
 const TestScreen = () => (

--- a/docs/versioned_docs/version-1.0.x/headers/avatar-header.md
+++ b/docs/versioned_docs/version-1.0.x/headers/avatar-header.md
@@ -9,7 +9,7 @@ sidebar_position: 4
 ## Example usage
 
 ```tsx
-import React from 'react'
+import * as React from 'react'
 import {
   AvatarHeaderScrollView,
   AvatarHeaderFlatList,

--- a/docs/versioned_docs/version-1.0.x/headers/custom-header.md
+++ b/docs/versioned_docs/version-1.0.x/headers/custom-header.md
@@ -7,7 +7,7 @@ sidebar_position: 5
 ## Example usage
 
 ```tsx
-import React from 'react';
+import * as React from 'react';
 import { View } from 'react-native';
 import {
   StickyHeaderScrollView,

--- a/docs/versioned_docs/version-1.0.x/headers/details-header.md
+++ b/docs/versioned_docs/version-1.0.x/headers/details-header.md
@@ -9,7 +9,7 @@ sidebar_position: 3
 ## Example usage
 
 ```tsx
-import React from 'react'
+import * as React from 'react'
 import {
   DetailsHeaderScrollView,
   DetailsHeaderFlatList,

--- a/docs/versioned_docs/version-1.0.x/headers/flashlist-headers.md
+++ b/docs/versioned_docs/version-1.0.x/headers/flashlist-headers.md
@@ -14,7 +14,7 @@ To make [FlashList](https://shopify.github.io/flash-list/docs/) work with react-
 
 ```tsx
 import { FlashList } from '@shopify/flash-list'
-import React from 'react'
+import * as React from 'react'
 import {
   withAvatarHeaderFlashList,
   withDetailsHeaderFlashList,

--- a/docs/versioned_docs/version-1.0.x/headers/tabbed-header-list.md
+++ b/docs/versioned_docs/version-1.0.x/headers/tabbed-header-list.md
@@ -9,7 +9,7 @@ sidebar_position: 2
 ## Example usage
 
 ```tsx
-import React from 'react';
+import * as React from 'react';
 import { Text, View } from 'react-native';
 import { TabbedHeaderList } from 'react-native-sticky-parallax-header';
 

--- a/docs/versioned_docs/version-1.0.x/headers/tabbed-header-pager.md
+++ b/docs/versioned_docs/version-1.0.x/headers/tabbed-header-pager.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 ## Example usage
 
 ```tsx
-import React from 'react';
+import * as React from 'react';
 import { Text, View } from 'react-native';
 import { TabbedHeaderPager } from 'react-native-sticky-parallax-header';
 

--- a/docs/versioned_docs/version-1.0.x/introduction/getting-started.md
+++ b/docs/versioned_docs/version-1.0.x/introduction/getting-started.md
@@ -57,7 +57,7 @@ As with primitive components, FlashList can also be customized to create its own
 This is how you can display header in your app:
 
 ```tsx
-import React from 'react'
+import * as React from 'react'
 import { DetailsHeaderScrollView } from 'react-native-sticky-parallax-header'
 
 const TestScreen = () => (

--- a/example/src/assets/data/paragraphs.tsx
+++ b/example/src/assets/data/paragraphs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { SectionListData } from 'react-native';
 
 import { Paragraph } from '../../components/primitiveComponents/Paragraph';

--- a/example/src/components/exampleComponents/QuizCard.tsx
+++ b/example/src/components/exampleComponents/QuizCard.tsx
@@ -1,5 +1,4 @@
-import type { VFC } from 'react';
-import React, { useCallback, useState } from 'react';
+import * as React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import type { Card, Question } from '../../assets/data/cards';
@@ -23,10 +22,10 @@ type Props = {
   cardsAmount: number;
 };
 
-const QuizCard: VFC<Props> = ({ data: { question, cards }, num, onPress, cardsAmount }) => {
-  const [revealed, setRevealed] = useState(false);
+const QuizCard: React.FC<Props> = ({ data: { question, cards }, num, onPress, cardsAmount }) => {
+  const [revealed, setRevealed] = React.useState(false);
 
-  const reveal = useCallback(() => {
+  const reveal = React.useCallback(() => {
     setRevealed(true);
   }, []);
 

--- a/example/src/components/exampleComponents/QuizListElement.tsx
+++ b/example/src/components/exampleComponents/QuizListElement.tsx
@@ -1,5 +1,4 @@
-import type { VFC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import type { ImageSourcePropType } from 'react-native';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
@@ -16,7 +15,7 @@ type Props = {
   pressUser?: () => void;
 };
 
-const QuizListElement: VFC<Props> = ({
+const QuizListElement: React.FC<Props> = ({
   onPress,
   authorName,
   imageSource,

--- a/example/src/components/exampleComponents/QuizOption.tsx
+++ b/example/src/components/exampleComponents/QuizOption.tsx
@@ -1,5 +1,4 @@
-import type { VFC } from 'react';
-import React, { useCallback, useState } from 'react';
+import * as React from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import { Image, StyleSheet, Text, TouchableOpacity, View, useWindowDimensions } from 'react-native';
 
@@ -15,18 +14,18 @@ type Props = {
 
 const QUIZ_OPTION_WIDTH_PERCENTAGE = 0.75;
 
-const QuizOption: VFC<Props> = ({ reveal, revealed, card: { number, question, value } }) => {
+const QuizOption: React.FC<Props> = ({ reveal, revealed, card: { number, question, value } }) => {
   const { width: windowWidth } = useWindowDimensions();
-  const [picked, setPicked] = useState(false);
-  const [paddingVertical, setPaddingVertical] = useState(0);
-  const calcPaddings = useCallback((event: LayoutChangeEvent) => {
+  const [picked, setPicked] = React.useState(false);
+  const [paddingVertical, setPaddingVertical] = React.useState(0);
+  const calcPaddings = React.useCallback((event: LayoutChangeEvent) => {
     const { height } = event.nativeEvent.layout;
     const circleRadius = 40;
     const padding = height > circleRadius ? height / 2.5 : 0;
 
     setPaddingVertical(padding);
   }, []);
-  const onPress = useCallback(() => {
+  const onPress = React.useCallback(() => {
     reveal();
     setPicked(true);
   }, [reveal]);

--- a/example/src/components/exampleComponents/UserModal.tsx
+++ b/example/src/components/exampleComponents/UserModal.tsx
@@ -1,5 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import * as React from 'react';
 import { StatusBar, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AvatarHeaderScrollView } from 'react-native-sticky-parallax-header';
@@ -20,10 +20,10 @@ interface Props {
 const UserModal: React.FC<Props> = ({ setModalVisible, user, onPressCloseModal }) => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const insets = useSafeAreaInsets();
-  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>();
 
   const title = "Author's Quizes";
-  const cards = useMemo(
+  const cards = React.useMemo(
     () => [
       {
         id: '4850294857',
@@ -37,7 +37,7 @@ const UserModal: React.FC<Props> = ({ setModalVisible, user, onPressCloseModal }
     [user]
   );
 
-  useEffect(() => {
+  React.useEffect(() => {
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
@@ -45,7 +45,7 @@ const UserModal: React.FC<Props> = ({ setModalVisible, user, onPressCloseModal }
     };
   }, []);
 
-  const onQuizListElementPress = useCallback(() => {
+  const onQuizListElementPress = React.useCallback(() => {
     setModalVisible(false);
     timeoutRef.current = setTimeout(() => {
       navigation.navigate('Card', { user });

--- a/example/src/components/predefinedComponents/TabbedSectionHeader.tsx
+++ b/example/src/components/predefinedComponents/TabbedSectionHeader.tsx
@@ -1,12 +1,11 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import { StyleSheet, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import type { SectionType } from '../../assets/data/tabbedSections';
 import { colors } from '../../constants';
 
-export const TabbedSectionHeader: FC<SectionType> = ({ title }) => {
+export const TabbedSectionHeader: React.FC<SectionType> = ({ title }) => {
   return (
     <SafeAreaView edges={['left', 'right']} style={styles.sectionContainer}>
       <Text style={styles.sectionTitle}>{title}</Text>

--- a/example/src/components/predefinedComponents/TabbedSectionItem.tsx
+++ b/example/src/components/predefinedComponents/TabbedSectionItem.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import React, { memo } from 'react';
+import * as React from 'react';
 import { Image, Platform, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -11,7 +10,7 @@ const ITEM_MARGIN_VERTICAL = 5;
 
 export const TABBED_SECTION_ITEM_HEIGHT = ITEM_HEIGHT + 2 * ITEM_MARGIN_VERTICAL;
 
-export const TabbedSectionItem: FC<ItemType> = memo(({ imageUrl, title, subtitle }) => {
+export const TabbedSectionItem: React.FC<ItemType> = React.memo(({ imageUrl, title, subtitle }) => {
   return (
     <SafeAreaView edges={['left', 'right']} style={styles.container}>
       <View style={styles.itemContainer}>

--- a/example/src/components/primitiveComponents/Header.tsx
+++ b/example/src/components/primitiveComponents/Header.tsx
@@ -1,8 +1,7 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import { Image, PixelRatio, StyleSheet, View } from 'react-native';
 
-export const Header: FC = () => {
+export const Header: React.FC = () => {
   return (
     <View style={styles.headerContainer}>
       <Image

--- a/example/src/components/primitiveComponents/Paragraph.tsx
+++ b/example/src/components/primitiveComponents/Paragraph.tsx
@@ -1,10 +1,9 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import { Platform, Pressable, StyleSheet, Text } from 'react-native';
 
 import { colors, screenStyles } from '../../constants';
 
-export const Paragraph: FC<{ text: string }> = ({ text }) => {
+export const Paragraph: React.FC<{ text: string }> = ({ text }) => {
   return (
     <Pressable
       android_ripple={{

--- a/example/src/components/primitiveComponents/SectionFooter.tsx
+++ b/example/src/components/primitiveComponents/SectionFooter.tsx
@@ -1,10 +1,9 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { colors } from '../../constants';
 
-export const SectionFooter: FC = () => {
+export const SectionFooter: React.FC = () => {
   return (
     <View style={styles.sectionFooterContainer}>
       <Text style={styles.sectionFooterLabel}>Section footer</Text>

--- a/example/src/components/primitiveComponents/SectionHeader.tsx
+++ b/example/src/components/primitiveComponents/SectionHeader.tsx
@@ -1,10 +1,9 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { colors } from '../../constants';
 
-export const SectionHeader: FC = () => {
+export const SectionHeader: React.FC = () => {
   return (
     <View style={styles.sectionHeaderContainer}>
       <Text style={styles.sectionHeaderLabel}>Section header</Text>

--- a/example/src/components/primitiveComponents/Tabs.tsx
+++ b/example/src/components/primitiveComponents/Tabs.tsx
@@ -1,10 +1,9 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import { PixelRatio, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { colors, screenStyles } from '../../constants';
 
-export const Tabs: FC = () => {
+export const Tabs: React.FC = () => {
   return (
     <View style={styles.tabsContainer}>
       <Tab title="Tab 1" />
@@ -16,7 +15,7 @@ export const Tabs: FC = () => {
   );
 };
 
-const Tab: FC<{ title: string }> = ({ title }) => {
+const Tab: React.FC<{ title: string }> = ({ title }) => {
   return (
     <Pressable
       android_ripple={{

--- a/example/src/screens/CardScreen/index.tsx
+++ b/example/src/screens/CardScreen/index.tsx
@@ -1,6 +1,5 @@
 import { useNavigation, useRoute } from '@react-navigation/native';
-import type { VFC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import { StatusBar, View } from 'react-native';
 import { DetailsHeaderScrollView } from 'react-native-sticky-parallax-header';
 
@@ -12,7 +11,7 @@ import type { CardRouteProp, RootStackNavigationProp } from '../../navigation/ty
 
 import { cardScreenTestIDs } from './testIDs';
 
-const CardScreen: VFC = () => {
+const CardScreen: React.FC = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const route = useRoute<CardRouteProp>();
   const user = route.params?.user ?? Brandon;

--- a/example/src/screens/HomeScreen/index.tsx
+++ b/example/src/screens/HomeScreen/index.tsx
@@ -1,6 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
-import type { VFC } from 'react';
-import React, { useCallback, useState } from 'react';
+import * as React from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import {
   Modal,
@@ -29,16 +28,16 @@ const wait = (timeout: number) =>
     setTimeout(resolve, timeout);
   });
 
-const HomeScreen: VFC = () => {
+const HomeScreen: React.FC = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const { height: windowHeight } = useWindowDimensions();
 
-  const [refreshing, setRefreshing] = useState<boolean>(false);
-  const [modalVisible, setModalVisible] = useState<boolean>(false);
-  const [userSelected, setUserSelected] = useState<User>();
-  const [contentHeight, setContentHeight] = useState<{ [key: string]: number }>({});
+  const [refreshing, setRefreshing] = React.useState<boolean>(false);
+  const [modalVisible, setModalVisible] = React.useState<boolean>(false);
+  const [userSelected, setUserSelected] = React.useState<User>();
+  const [contentHeight, setContentHeight] = React.useState<{ [key: string]: number }>({});
 
-  const openUserModal = useCallback((user: User) => {
+  const openUserModal = React.useCallback((user: User) => {
     setUserSelected(() => {
       setModalVisible(true);
 
@@ -46,7 +45,7 @@ const HomeScreen: VFC = () => {
     });
   }, []);
 
-  const onRefresh = useCallback(() => {
+  const onRefresh = React.useCallback(() => {
     setRefreshing(true);
 
     wait(2000).then(() => {
@@ -83,7 +82,7 @@ const HomeScreen: VFC = () => {
     });
   };
 
-  const navigateToCardScreen = useCallback(
+  const navigateToCardScreen = React.useCallback(
     (user: User) => {
       return () => {
         navigation.navigate('Card', { user });
@@ -92,7 +91,7 @@ const HomeScreen: VFC = () => {
     [navigation]
   );
 
-  const pressUserModal = useCallback(
+  const pressUserModal = React.useCallback(
     (user: User) => {
       return () => {
         openUserModal(user);
@@ -101,7 +100,7 @@ const HomeScreen: VFC = () => {
     [openUserModal]
   );
 
-  const onPressCloseModal = useCallback(() => {
+  const onPressCloseModal = React.useCallback(() => {
     setModalVisible(false);
   }, []);
 

--- a/example/src/screens/SimsScreen/Foreground.tsx
+++ b/example/src/screens/SimsScreen/Foreground.tsx
@@ -1,5 +1,4 @@
-import type { VFC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import Animated, { Extrapolate, interpolate, useAnimatedStyle } from 'react-native-reanimated';
 
@@ -12,7 +11,7 @@ interface ForegroundProps {
   scrollValue: Animated.SharedValue<number>;
 }
 
-export const Foreground: VFC<ForegroundProps> = ({ scrollValue }) => {
+export const Foreground: React.FC<ForegroundProps> = ({ scrollValue }) => {
   const foregroundWrapperAnimatedStyle = useAnimatedStyle(() => {
     return { opacity: interpolate(scrollValue.value, [0, 250, 330], [1, 1, 0], Extrapolate.CLAMP) };
   });

--- a/example/src/screens/SimsScreen/HeaderBar.tsx
+++ b/example/src/screens/SimsScreen/HeaderBar.tsx
@@ -1,7 +1,6 @@
 import { useNavigation } from '@react-navigation/native';
 import { BlurView } from 'expo-blur';
-import type { VFC } from 'react';
-import React, { useCallback } from 'react';
+import * as React from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import Animated, { Extrapolate, interpolate, useAnimatedStyle } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -16,10 +15,10 @@ interface HeaderBarProps {
 
 const DEFAULT_TOP_INSET = 30;
 
-export const HeaderBar: VFC<HeaderBarProps> = ({ scrollValue }) => {
+export const HeaderBar: React.FC<HeaderBarProps> = ({ scrollValue }) => {
   const navigation = useNavigation();
 
-  const goBack = useCallback(() => {
+  const goBack = React.useCallback(() => {
     navigation.goBack();
   }, [navigation]);
 

--- a/example/src/screens/SimsScreen/index.tsx
+++ b/example/src/screens/SimsScreen/index.tsx
@@ -1,5 +1,4 @@
-import type { VFC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import type { ScrollView } from 'react-native';
 import { StatusBar, StyleSheet, Text, View, useWindowDimensions } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -20,7 +19,7 @@ const HEADER_BAR_HEIGHT = 92;
 const SNAP_START_THRESHOLD = 50;
 const SNAP_STOP_THRESHOLD = 330;
 
-const SimsScreen: VFC = () => {
+const SimsScreen: React.FC = () => {
   const { width: windowWidth } = useWindowDimensions();
   const {
     onMomentumScrollEnd,

--- a/example/src/screens/YodaScreen/HeaderBar.tsx
+++ b/example/src/screens/YodaScreen/HeaderBar.tsx
@@ -1,6 +1,5 @@
 import { useNavigation } from '@react-navigation/native';
-import type { VFC } from 'react';
-import React, { useCallback } from 'react';
+import * as React from 'react';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import Animated, { Extrapolate, interpolate, useAnimatedStyle } from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -13,9 +12,9 @@ interface HeaderBarProps {
   scrollValue: Animated.SharedValue<number>;
 }
 
-export const HeaderBar: VFC<HeaderBarProps> = ({ scrollValue }) => {
+export const HeaderBar: React.FC<HeaderBarProps> = ({ scrollValue }) => {
   const navigation = useNavigation();
-  const goBack = useCallback(() => {
+  const goBack = React.useCallback(() => {
     navigation.goBack();
   }, [navigation]);
 

--- a/example/src/screens/YodaScreen/index.tsx
+++ b/example/src/screens/YodaScreen/index.tsx
@@ -1,5 +1,4 @@
-import type { VFC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import type { NativeScrollEvent } from 'react-native';
 import { StatusBar, StyleSheet, Text, View, useWindowDimensions } from 'react-native';
 import { useSharedValue } from 'react-native-reanimated';
@@ -11,7 +10,7 @@ import { HeaderBar } from './HeaderBar';
 import { TABS } from './data';
 import { yodaScreenTestIDs } from './testIDs';
 
-const YodaScreen: VFC = () => {
+const YodaScreen: React.FC = () => {
   const { height: windowHeight } = useWindowDimensions();
   const scrollValue = useSharedValue(0);
 

--- a/src/predefinedComponents/AvatarHeader/components/HeaderBar.tsx
+++ b/src/predefinedComponents/AvatarHeader/components/HeaderBar.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import type {
   ColorValue,
   ImageSourcePropType,
@@ -34,7 +33,7 @@ interface HeaderProps extends IconProps {
   titleTestID?: string;
 }
 
-export const HeaderBar: FC<HeaderProps> = ({
+export const HeaderBar: React.FC<HeaderProps> = ({
   backgroundColor,
   height,
   image,

--- a/src/predefinedComponents/AvatarHeader/components/HeaderForeground.tsx
+++ b/src/predefinedComponents/AvatarHeader/components/HeaderForeground.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import type { ImageSourcePropType, StyleProp, TextStyle, ViewStyle } from 'react-native';
 import { StyleSheet, Text, View, useWindowDimensions } from 'react-native';
 import Animated, { Extrapolate, interpolate, useAnimatedStyle } from 'react-native-reanimated';
@@ -24,7 +23,7 @@ interface ForegroundProps {
 const finishImgPosition = 31;
 const startImgPosition = 27;
 
-export const Foreground: FC<ForegroundProps> = ({
+export const Foreground: React.FC<ForegroundProps> = ({
   height,
   image,
   scrollValue,

--- a/src/predefinedComponents/DetailsHeader/components/HeaderBar.tsx
+++ b/src/predefinedComponents/DetailsHeader/components/HeaderBar.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import type { ColorValue, StyleProp, TextStyle } from 'react-native';
 import { Pressable, StyleSheet, Text } from 'react-native';
 import Animated from 'react-native-reanimated';
@@ -24,7 +23,7 @@ const HIT_SLOP = {
   right: 15,
 };
 
-export const HeaderBar: FC<HeaderBarProps> = ({
+export const HeaderBar: React.FC<HeaderBarProps> = ({
   backgroundColor,
   headerTitleContainerAnimatedStyle,
   leftTopIcon,

--- a/src/predefinedComponents/DetailsHeader/components/HeaderForeground.tsx
+++ b/src/predefinedComponents/DetailsHeader/components/HeaderForeground.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import type { ImageSourcePropType, StyleProp, TextStyle, ViewStyle } from 'react-native';
 import { Image, Platform, StyleSheet, Text, View, useWindowDimensions } from 'react-native';
 import Animated, { Extrapolate, interpolate, useAnimatedStyle } from 'react-native-reanimated';
@@ -27,7 +26,7 @@ interface ForegroundProps {
   titleTestID?: string;
 }
 
-export const Foreground: FC<ForegroundProps> = ({
+export const Foreground: React.FC<ForegroundProps> = ({
   contentIcon,
   contentIconNumber,
   contentIconNumberStyle,

--- a/src/predefinedComponents/TabbedHeader/components/HeaderBar.tsx
+++ b/src/predefinedComponents/TabbedHeader/components/HeaderBar.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import type {
   ColorValue,
   ImageResizeMode,
@@ -21,7 +20,7 @@ interface HeaderBarProps {
   logoStyle?: StyleProp<ImageStyle>;
 }
 
-export const HeaderBar: FC<HeaderBarProps> = ({
+export const HeaderBar: React.FC<HeaderBarProps> = ({
   backgroundColor,
   logo,
   logoResizeMode,

--- a/src/predefinedComponents/TabbedHeader/components/HeaderForeground.tsx
+++ b/src/predefinedComponents/TabbedHeader/components/HeaderForeground.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import type { ImageSourcePropType, StyleProp, TextStyle, ViewStyle } from 'react-native';
 import { StyleSheet, Text, View, useWindowDimensions } from 'react-native';
 import Animated, { Extrapolate, interpolate, useAnimatedStyle } from 'react-native-reanimated';
@@ -18,7 +17,7 @@ interface ForegroundProps {
   titleTestID?: string;
 }
 
-export const Foreground: FC<ForegroundProps> = ({
+export const Foreground: React.FC<ForegroundProps> = ({
   foregroundImage,
   height,
   scrollValue,

--- a/src/predefinedComponents/TabbedHeader/components/Tabs.tsx
+++ b/src/predefinedComponents/TabbedHeader/components/Tabs.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import React, { useCallback, useEffect, useRef } from 'react';
+import * as React from 'react';
 import type { LayoutChangeEvent, ListRenderItemInfo } from 'react-native';
 import {
   FlatList,
@@ -24,7 +23,7 @@ export interface TabsProps extends TabsConfig {
 
 const UNDERLINE_PADDING = 20;
 
-export const Tabs: FC<TabsProps> = ({
+export const Tabs: React.FC<TabsProps> = ({
   tabs,
   activeTab,
   onTabPressed,
@@ -40,15 +39,15 @@ export const Tabs: FC<TabsProps> = ({
   tabsContainerHorizontalPadding,
 }) => {
   const { width } = useWindowDimensions();
-  const horizontalFlatListRef = useRef<FlatList>(null);
+  const horizontalFlatListRef = React.useRef<FlatList>(null);
 
-  const currentPositionX = useRef(0);
-  const tabsWidth = useRef(tabs.map((_) => 0));
+  const currentPositionX = React.useRef(0);
+  const tabsWidth = React.useRef(tabs.map((_) => 0));
 
   /** For some weird reason, inverted prop is not handled correctly, when applied directly with FlatList */
   const isInverted = Platform.OS === 'android' ? I18nManager.isRTL : undefined;
 
-  const adjustPrevious = useCallback(
+  const adjustPrevious = React.useCallback(
     (page: number) => {
       const lastHidden = Math.floor(currentPositionX.current / (width * 0.3));
 
@@ -60,7 +59,7 @@ export const Tabs: FC<TabsProps> = ({
     [width]
   );
 
-  const adjustNext = useCallback(
+  const adjustNext = React.useCallback(
     (page: number) => {
       const invisibleX = width + currentPositionX.current - width * 0.3 * (page + 1);
 
@@ -72,7 +71,7 @@ export const Tabs: FC<TabsProps> = ({
     [width]
   );
 
-  const scrollToTab = useCallback(
+  const scrollToTab = React.useCallback(
     (page: number) => {
       if (tabs.length > 3) {
         if (page === 0) {
@@ -90,29 +89,29 @@ export const Tabs: FC<TabsProps> = ({
     [adjustNext, adjustPrevious, tabs.length, width]
   );
 
-  const scrollToTabRef = useRef(scrollToTab);
+  const scrollToTabRef = React.useRef(scrollToTab);
 
-  useEffect(() => {
+  React.useEffect(() => {
     scrollToTabRef.current = scrollToTab;
   }, [scrollToTab]);
 
-  useEffect(() => {
+  React.useEffect(() => {
     scrollToTabRef.current(activeTab);
   }, [activeTab]);
 
-  useEffect(() => {
+  React.useEffect(() => {
     horizontalFlatListRef.current?.scrollToOffset({ offset: 1 });
     horizontalFlatListRef.current?.scrollToOffset({ offset: 0 });
   }, []);
 
-  const onTabLayout = useCallback(
+  const onTabLayout = React.useCallback(
     (page: number) => (e: LayoutChangeEvent) => {
       tabsWidth.current[page] = e.nativeEvent.layout.width;
     },
     []
   );
 
-  const onTabPress = useCallback(
+  const onTabPress = React.useCallback(
     (page: number) => {
       return function () {
         scrollToTab(page);
@@ -122,7 +121,7 @@ export const Tabs: FC<TabsProps> = ({
     [onTabPressed, scrollToTab]
   );
 
-  const renderIcon = useCallback(
+  const renderIcon = React.useCallback(
     (icon: Tab['icon'], page: number) => {
       const isActive = activeTab === page;
 
@@ -147,7 +146,7 @@ export const Tabs: FC<TabsProps> = ({
     };
   });
 
-  const renderItem = useCallback(
+  const renderItem = React.useCallback(
     ({ item: tab, index: page }: ListRenderItemInfo<Tab>) => {
       const isTabActive = activeTab === page;
       const tabKey = tab.title || `tab ${page}`;

--- a/src/predefinedComponents/common/components/HeaderBackground.tsx
+++ b/src/predefinedComponents/common/components/HeaderBackground.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import type { ColorValue } from 'react-native';
 import { StyleSheet } from 'react-native';
 import Animated, { Extrapolate, interpolate, useAnimatedStyle } from 'react-native-reanimated';
@@ -11,7 +10,7 @@ interface HeaderBackgroundProps {
   scrollValue: Animated.SharedValue<number>;
 }
 
-export const HeaderBackground: FC<HeaderBackgroundProps> = ({
+export const HeaderBackground: React.FC<HeaderBackgroundProps> = ({
   backgroundColor,
   hasBorderRadius,
   height,

--- a/src/predefinedComponents/common/components/HeaderBackgroundImage.tsx
+++ b/src/predefinedComponents/common/components/HeaderBackgroundImage.tsx
@@ -1,15 +1,14 @@
-import type { ReactNode, VFC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import type { ImageSourcePropType } from 'react-native';
 import { ImageBackground, StyleSheet, useWindowDimensions } from 'react-native';
 
 interface HeaderBackgroundImageProps {
-  background: ReactNode;
+  background: React.ReactNode;
   backgroundHeight: number;
   backgroundImage: ImageSourcePropType;
 }
 
-export const HeaderBackgroundImage: VFC<HeaderBackgroundImageProps> = ({
+export const HeaderBackgroundImage: React.FC<HeaderBackgroundImageProps> = ({
   background,
   backgroundHeight,
   backgroundImage,

--- a/src/predefinedComponents/common/components/HeaderWrapper.tsx
+++ b/src/predefinedComponents/common/components/HeaderWrapper.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import type { ColorValue, ImageSourcePropType } from 'react-native';
 import { StyleSheet, View, useWindowDimensions } from 'react-native';
 import type Animated from 'react-native-reanimated';
@@ -20,7 +19,7 @@ interface HeaderWrapperProps {
   tabsContainerBackgroundColor?: ColorValue;
 }
 
-export const HeaderWrapper: FC<HeaderWrapperProps> = ({
+export const HeaderWrapper: React.FC<React.PropsWithChildren<HeaderWrapperProps>> = ({
   backgroundColor,
   backgroundImage,
   children,

--- a/src/predefinedComponents/common/components/IconRenderer.tsx
+++ b/src/predefinedComponents/common/components/IconRenderer.tsx
@@ -1,13 +1,12 @@
-import type { ReactElement, VFC } from 'react';
-import React from 'react';
+import * as React from 'react';
 import type { ImageSourcePropType } from 'react-native';
 import { Image, StyleSheet } from 'react-native';
 
 interface Props {
-  icon?: (() => ReactElement | null) | ImageSourcePropType;
+  icon?: (() => React.ReactElement | null) | ImageSourcePropType;
 }
 
-const IconRenderer: VFC<Props> = ({ icon }) => {
+const IconRenderer: React.FC<Props> = ({ icon }) => {
   if (typeof icon === 'function') {
     return icon();
   }

--- a/src/primitiveComponents/withStickyHeader.tsx
+++ b/src/primitiveComponents/withStickyHeader.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { ComponentPropsWithRef, ComponentType, FC } from 'react';
-import React, { forwardRef, useMemo } from 'react';
+import * as React from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import { StyleSheet, View } from 'react-native';
 import Animated from 'react-native-reanimated';
@@ -23,10 +22,10 @@ const createCellRenderer = (itemLayoutAnimation: any) => {
   return cellRenderer;
 };
 
-export function withStickyHeader<T extends ComponentType<any>>(component: T) {
+export function withStickyHeader<T extends React.ComponentType<any>>(component: T) {
   const AnimatedComponent = Animated.createAnimatedComponent(component as any) as any;
 
-  return forwardRef<
+  return React.forwardRef<
     T,
     StickyHeaderSharedProps & Animated.AnimateProps<React.ComponentPropsWithRef<T>>
   >((props, ref) => {
@@ -52,7 +51,7 @@ export function withStickyHeader<T extends ComponentType<any>>(component: T) {
       tabsHeight,
     } = useStickyHeaderProps(props);
 
-    const cellRenderer = useMemo(
+    const cellRenderer = React.useMemo(
       () => createCellRenderer(itemLayoutAnimation),
       // eslint-disable-next-line react-hooks/exhaustive-deps
       []
@@ -98,7 +97,9 @@ export function withStickyHeader<T extends ComponentType<any>>(component: T) {
         />
       </View>
     );
-  }) as unknown as FC<StickyHeaderSharedProps & Animated.AnimateProps<ComponentPropsWithRef<T>>>;
+  }) as unknown as React.FC<
+    StickyHeaderSharedProps & Animated.AnimateProps<React.ComponentPropsWithRef<T>>
+  >;
 }
 
 export const styles = StyleSheet.create({


### PR DESCRIPTION
- replaced all `import React` with `import * as React`
- removed deprecated `React.VFC`
- added `React.PropsWithChildren` to all `React.FC` components that used `children` prop