### PR TITLE
Docs/improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,18 @@
 
 ## Running/Development
 1. iOS:
-```bash
-$ react-native run-ios
+```sh
+yarn example ios
 ```
 
 2. Android:
-```bash
-$ react-native run-android
+```sh
+yarn example android
 ```
 
 ## Running Tests
-```bash
-$ yarn test
+```sh
+yarn test
 ```
 
 ## Creating new Pull Request

--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ This is how you can display header in your app:
 ```tsx
 import * as React from 'react'
 import { DetailsHeaderScrollView } from 'react-native-sticky-parallax-header'
+import { SafeAreaProvider } from 'react-native-safe-area-context'
 
 const TestScreen = () => (
-  <>
+  <SafeAreaProvider>
     <DetailsHeaderScrollView {...scrollProps} {...detailsHeaderProps}>
       {/** scroll view content */}
     </DetailsHeaderScrollView>
-  </>
+  </SafeAreaProvider>
 )
 
 export default TestScreen
@@ -74,6 +75,10 @@ $ yarn add react-native-sticky-parallax-header@rc
 yarn add react-native-reanimated react-native-safe-area-context
 ```
 
+After installation:
+- check Reanimated installation [guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation)
+- handle Pods installation with `npx pod-install`
+- wrap your root component with `SafeAreaProvider` from `react-native-safe-area-context
 
 <h1 id="Contributing">Contributing</h1>
 

--- a/docs/docs/examples/custom-flashlist-header.md
+++ b/docs/docs/examples/custom-flashlist-header.md
@@ -8,3 +8,65 @@ Analogically to [custom headers](./custom-header.md), react-native-sticky-parall
 
 - `useStickyHeaderFlashListScrollProps` equivalent for [`useStickyHeaderScrollProps`](./custom-header.md#scroll-props)
 - `withStickyHeaderFlashList` equivalent for `withStickyHeader`
+
+Full source code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/StickyHeaderFlashListExample.tsx)
+
+```tsx
+const PARALLAX_HEIGHT = 330;
+const HEADER_BAR_HEIGHT = 92;
+const SNAP_START_THRESHOLD = 50;
+const SNAP_STOP_THRESHOLD = 330;
+
+const StickyHeaderFlashList = withStickyHeaderFlashList(FlashList) as (
+  props: StickyHeaderFlashListProps<string> & React.RefAttributes<FlashList<string>>
+) => React.ReactElement;
+
+const StickyHeaderFlashListExample: React.FC = () => {
+  const { width: windowWidth } = useWindowDimensions();
+  const {
+    onMomentumScrollEnd,
+    onScroll,
+    onScrollEndDrag,
+    scrollHeight,
+    scrollValue,
+    scrollViewRef,
+  } = useStickyHeaderFlashListScrollProps({
+    parallaxHeight: PARALLAX_HEIGHT,
+    snapStartThreshold: SNAP_START_THRESHOLD,
+    snapStopThreshold: SNAP_STOP_THRESHOLD,
+    snapToEdge: true,
+  });
+
+  return (
+    <View style={screenStyles.screenContainer}>
+      <View style={[styles.headerBarContainer, { width: windowWidth }]}>
+        <HeaderBar scrollValue={scrollValue} />
+      </View>
+      <View style={screenStyles.stretchContainer}>
+        <StickyHeaderFlashList
+          ref={scrollViewRef}
+          containerStyle={screenStyles.stretchContainer}
+          onScroll={onScroll}
+          onMomentumScrollEnd={onMomentumScrollEnd}
+          onScrollEndDrag={onScrollEndDrag}
+          estimatedItemSize={400}
+          renderItem={({ item }) => {
+            return <Paragraph text={item} />;
+          }}
+          renderTabs={() => <Tabs />}
+          renderHeader={() => {
+            return (
+              <View pointerEvents="box-none" style={{ height: scrollHeight }}>
+                <Foreground scrollValue={scrollValue} />
+              </View>
+            );
+          }}
+          showsVerticalScrollIndicator={false}
+          style={screenStyles.stretch}
+        />
+      </View>
+      <StatusBar barStyle="light-content" backgroundColor={colors.black} translucent />
+    </View>
+  );
+};
+```

--- a/docs/docs/examples/custom-header.md
+++ b/docs/docs/examples/custom-header.md
@@ -6,77 +6,69 @@ sidebar_position: 2
 
 To create custom header layout, you'll have to use `StickyHeader(ScrollView|FlatList|SectionList)` & `useStickyHeaderScrollProps`. If you want to use custom scroll component, instead of `StickyHeader(ScrollView|FlatList|SectionList)`, you can wrap your custom scroll component in `withStickyHeader` HOC.
 
-## Scroll props
+For scroll props use `useStickyHeaderScrollProps` hook, which is responsible for creating "snap effect" behavior.
 
-`useStickyHeaderScrollProps` is a hook responsible for creating "snap effect" behavior
+Props returned from `useStickyHeaderScrollProps` should be passed to sticky header component (`StickyHeader(ScrollView|FlatList|SectionList)` or `withStickyHeader` decorated scroll component).
 
-```tsx
-const {
-  onMomentumScrollEnd,
-  onScroll,
-  onScrollEndDrag,
-  scrollHeight,
-  scrollValue,
-  scrollViewRef,
-} = useStickyHeaderScrollProps({
-  parallaxHeight: PARALLAX_HEIGHT,
-  snapStartThreshold: SNAP_START_THRESHOLD,
-  snapStopThreshold: SNAP_STOP_THRESHOLD,
-  snapToEdge: true,
-});
-```
-
-Props returned from `useStickyHeaderScrollProps` should be passed to sticky header component (`StickyHeader(ScrollView|FlatList|SectionList)` or `withStickyHeader` decorated scroll component)
-
-```tsx
-<StickyHeaderScrollView
-  ref={scrollViewRef}
-  onScroll={onScroll}
-  onMomentumScrollEnd={onMomentumScrollEnd}
-  onScrollEndDrag={onScrollEndDrag}
-  renderHeader={() => {
-    /** 
-     * If you need, pass `scrollHeight` & `scrollValue` from `useStickyHeaderScrollProps`
-     * 
-     * Remember to add pointerEvents="box-none" and pointerEvents="none" to header components, to make header part scrollable
-     */
-    return (
-      <View pointerEvents="box-none" style={{ height: scrollHeight }}>
-        <Foreground scrollValue={scrollValue} />
-      </View>
-    );
-  }}
-  // ...
-  >
-  {/** content */}
-</StickyHeaderScrollView>
-```
-
-## Display custom header/tabs layout
-
-To display custom header or tabs layout, use `renderHeader` & `renderTabs` props
-
-```tsx
-<StickyHeaderScrollView
-  // ...
-  renderHeader={() => {
-    /** 
-     * If you need, pass `scrollHeight` & `scrollValue` from `useStickyHeaderScrollProps`
-     * 
-     * Remember to add pointerEvents="box-none" and pointerEvents="none" to header components, to make header part scrollable
-     */
-    return (
-      <View pointerEvents="box-none" style={{ height: scrollHeight }}>
-        <Foreground scrollValue={scrollValue} />
-      </View>
-    );
-  }}
-  // ...
-  >
-  {/** content */}
-</StickyHeaderScrollView>
-```
-
-## Summary - Full source code
+To display custom header or tabs layout, use `renderHeader` & `renderTabs` props.
 
 Full source code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/SimsScreen/index.tsx)
+
+```tsx
+const PARALLAX_HEIGHT = 330;
+const HEADER_BAR_HEIGHT = 92;
+const SNAP_START_THRESHOLD = 50;
+const SNAP_STOP_THRESHOLD = 330;
+
+const SimsScreen: React.FC = () => {
+  const { width: windowWidth } = useWindowDimensions();
+  const {
+    onMomentumScrollEnd,
+    onScroll,
+    onScrollEndDrag,
+    scrollHeight,
+    scrollValue,
+    scrollViewRef,
+    // useStickyHeaderScrollProps is generic and need to know
+    // which component (ScrollView, FlatList<ItemT> or SectionList<ItemT, SectionT>)
+    // will be enhanced with sticky scroll props
+  } = useStickyHeaderScrollProps<ScrollView>({
+    parallaxHeight: PARALLAX_HEIGHT,
+    snapStartThreshold: SNAP_START_THRESHOLD,
+    snapStopThreshold: SNAP_STOP_THRESHOLD,
+    snapToEdge: true,
+  });
+
+  return (
+    <View style={screenStyles.screenContainer}>
+      <View style={[styles.headerBarContainer, { width: windowWidth }]}>
+        <HeaderBar scrollValue={scrollValue} />
+      </View>
+      <View style={screenStyles.stretchContainer}>
+        <StickyHeaderScrollView
+          ref={scrollViewRef}
+          containerStyle={screenStyles.stretchContainer}
+          onScroll={onScroll}
+          onMomentumScrollEnd={onMomentumScrollEnd}
+          onScrollEndDrag={onScrollEndDrag}
+          renderHeader={() => {
+            return (
+              <View pointerEvents="box-none" style={{ height: scrollHeight }}>
+                <Foreground scrollValue={scrollValue} />
+              </View>
+            );
+          }}
+          showsVerticalScrollIndicator={false}
+          style={screenStyles.stretch}>
+          <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.content}>
+            <Text style={screenStyles.text}>
+              {text}
+            </Text>
+          </SafeAreaView>
+        </StickyHeaderScrollView>
+      </View>
+      <StatusBar barStyle="light-content" backgroundColor={colors.black} translucent />
+    </View>
+  );
+};
+```

--- a/docs/docs/examples/custom-tabbed-header.md
+++ b/docs/docs/examples/custom-tabbed-header.md
@@ -6,25 +6,88 @@ sidebar_position: 1
 
 ## Tabbed Header Customisation
 
-Example of custom Tabbar Header styling. Whole source code can be found in the summary of this page.
-
 ![Tabbed Header Gif](@site/static/img/assets/readme_yoda.gif)
 
 ## Custom scrollable tabs
 
 To change tabs to your custom ones, pass `tabs` prop to `TabbedHeaderPager` component, where
-`title` is your tab name and then render each tab as a child of `TabbedHeaderPager`:
+`title` is your tab name and then render each tab as a child of `TabbedHeaderPager`
+
+## Custom tab styling
+
+When It comes to tab styling, in TabbedHeader provides following props:
+
+`tabTextStyle` and `tabTextActiveStyle` to pass styles for tab text whether is inactive or active
+
+`tabTextContainerStyle` and `tabTextContainerActiveStyle` to pass styles for tab containers
+
+`tabsContainerBackgroundColor` responsible for backgroundColor of tab bar
+
+`tabWrapperStyle` to pass style for single tab wrapper eg. to change vertical padding
+
+`tabsContainerStyle` to pass style for whole tab bar container eg. to change horizontal padding
+
+## Custom header foreground
+
+Instead of setting header color by `backgroundColor` prop, we can use `backgroundImage` and pass an image.
+
+In the TabbarHeader example there is a small avatar image and title below, we can set the first one by passing
+image to the `foregroundImage` prop.
+
+To customise title, we can pass it by title prop `title="Baby Yoda"` and then pass styles by `titleStyle` prop.
+
+## Custom Header component
+
+Instead of passing your own logo to the header, you can create component and pass it to the `renderHeaderBar` prop. It allows you to create back/close button and create custom animations
+
+In the example below there is custom header containing close button which is visible all the time, 
+and the title displayed on header, visible only when the header is in closed state.
+
+In order to do this, we save vertical content offset in a Reanimated's shared value and then use it to interpolate opacity value of the View with the title.
+
+## Example
+
+Full source code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/YodaScreen/index.tsx).
 
 ```tsx
 const text = {
-  biography: `The bounty hunter known as "the Mandalorian" was dispatched by "the Client" and Imperial Dr. Pershing to capture the Child alive, however the Client would allow the Mandalorian to return the Child dead for a lower price. ...`,
+  biography: `The bounty hunter known as "the Mandalorian" was dispatched by "the Client" and Imperial Dr. Pershing to capture the Child alive, however the Client would allow the Mandalorian to return the Child dead for a lower price.
+  The assassin droid IG-11 was also dispatched to terminate him. After working together to storm the encampment the infant was being held in, the Mandalorian and IG-11 found the Child. IG-11 then attempted to terminate the Child. The Mandalorian shot the droid before the he was able to assassinate the Child.
+  Shortly after, the Mandalorian took the Child back to his ship. On the way they were attacked by a trio of Trandoshan bounty hunters, who attempted to kill the Child. After the Mandalorian defeated them, he and the Child camped out in the desert for the night. While the Mandalorian sat by the fire, the Child ate one of the creatures moving around nearby. He then approached the bounty hunter and attempted to use the Force to heal one of the Mandalorian's wounds. The Mandalorian stopped him and placed him back into his pod. The next day, the pair made it to the Razor Crest only to find it being scavenged by Jawas. The Mandalorian attacked their sandcrawler for the scavenged parts and attempted to climb it while the Child followed in his pod. However, the Mandalorian was knocked down to the ground`,
   powers:
-    'Grogu was able to harness the mystical energies of the Force on account of being Force-sensitive. One notable display of his power was when he telekinetically lifted a giant mudhorn into the air for a brief time to save Djarin from the charging beast. ...',
+    'Grogu was able to harness the mystical energies of the Force on account of being Force-sensitive. One notable display of his power was when he telekinetically lifted a giant mudhorn into the air for a brief time to save Djarin from the charging beast. However, performing this feat was very strenuous for Grogu as he subsequently fell unconscious for several hours afterward. He could also use the Force when he became angry, such as when he telekinetically strangled Cara Dune because he believed she was harming Djarin while they were arm-wrestling. He later revealed the ability to heal serious injuries and even cure poisoning by touching the injury and then using the Force, though the act, much like levitating the mudhorn, was incredibly draining. In another notable display of telekinesis, Grogu created a strong barrier using the Force to protect his companions by both blocking and redirecting a stream of fire from an attacking Incinerator trooper.',
   appearances: `
   Star Wars: Galaxy of Heroes
   Star Wars: Squadrons (as toy) (DLC)
   The-Mandalorian-logo.png The Mandalorian - "Chapter 1: The Mandalorian" (First appearance)
-  ...`.trim(),
+  The Mandalorian: Season 1: Volume 1
+  Star Wars: The Mandalorian Junior Novel
+  The Mandalorian 1
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 2: The Child"
+  The Mandalorian 2
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 3: The Sin"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 4: Sanctuary"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 5: The Gunslinger"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 6: The Prisoner"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 7: The Reckoning"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 8: Redemption"
+  The Mandalorian: A Clan of Two
+  The Mandalorian: Magnetic Fun
+  The Mandalorian: This is the Way
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 9: The Marshal"
+  Star Wars: The Mandalorian Season 2 Junior Novel
+  The Mandalorian: The Path of the Force
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 10: The Passenger"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 11: The Heiress"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 12: The Siege"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 13: The Jedi" (First identified as Grogu)
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 14: The Tragedy"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 15: The Believer" (Mentioned only)
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 16: The Rescue"
+  The Book of Boba Fett logo.png The Book of Boba Fett - "Chapter 5: Return of the Mandalorian" (Mentioned only)
+  The Book of Boba Fett logo.png The Book of Boba Fett - "Chapter 6: From the Desert Comes a Stranger"
+  The Book of Boba Fett logo.png The Book of Boba Fett - "Chapter 7: In the Name of Honor"
+  `.trim(),
 };
 
 const TABS = [
@@ -42,57 +105,110 @@ const TABS = [
   },
 ];
 
-return (
-  <TabbedHeaderPager
-    //...
-    tabs={TABS}
-    //...
-  >
-    {TABS.map((tab, i) => (
-      <View key={i} style={...}>
-        <Text style={...}>{tab.description}</Text>
+const HeaderBar = ({ scrollValue }) => {
+  const navigation = useNavigation();
+  const goBack = React.useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return { opacity: interpolate(scrollValue.value, [0, 60, 90], [0, 0, 1], Extrapolate.CLAMP) };
+  });
+
+  return (
+    <SafeAreaView edges={['top', 'left', 'right']} style={styles.headerContainer}>
+      <View style={styles.headerWrapper}>
+        <TouchableOpacity onPress={goBack}>
+          <Image
+            style={styles.headerImage}
+            resizeMode="contain"
+            source={{
+              uri: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/VisualEditor_-_Icon_-_Close_-_white.svg/1200px-VisualEditor_-_Icon_-_Close_-_white.svg.png',
+            }}
+          />
+        </TouchableOpacity>
+        <Animated.View style={animatedStyle}>
+          <Text style={styles.headerText}>
+            Baby Yoda
+          </Text>
+        </Animated.View>
       </View>
-    ))}
-  </TabbedHeaderPager>
-)
-```
+    </SafeAreaView>
+  );
+};
 
-## Custom tab styling
+const YodaScreen: React.FC = () => {
+  const { height: windowHeight } = useWindowDimensions();
+  const scrollValue = useSharedValue(0);
 
-When It comes to tab styling, in TabbedHeader provides following props:
+  function onScroll(e: NativeScrollEvent) {
+    'worklet';
+    scrollValue.value = e.contentOffset.y;
+  }
 
-`tabTextStyle` and `tabTextActiveStyle` to pass styles for tab text whether is inactive or active
-
-`tabTextContainerStyle` and `tabTextContainerActiveStyle` to pass styles for tab containers
-
-`tabsContainerBackgroundColor` responsible for backgroundColor of tab bar
-
-`tabWrapperStyle` to pass style for single tab wrapper eg. to change vertical padding
-
-`tabsContainerStyle` to pass style for whole tab bar container eg. to change horizontal padding
-
-```tsx
+  return (
+    <>
+      <TabbedHeaderPager
+        containerStyle={screenStyles.stretchContainer}
+        backgroundImage={{
+          uri: 'https://miro.medium.com/max/1200/1*mk1-6aYaf_Bes1E3Imhc0A.jpeg',
+        }}
+        title="Baby Yoda"
+        titleStyle={styles.titleStyle}
+        foregroundImage={{
+          uri: 'https://cdn.iconscout.com/icon/free/png-256/starwars-6-569425.png',
+        }}
+        tabsContainerBackgroundColor={colors.black}
+        tabTextContainerStyle={styles.tabTextContainerStyle}
+        tabTextContainerActiveStyle={styles.tabTextContainerActiveStyle}
+        tabTextStyle={styles.tabText}
+        tabTextActiveStyle={styles.tabTextActiveStyle}
+        tabWrapperStyle={styles.tabWrapperStyle}
+        tabsContainerStyle={styles.tabsContainerStyle}
+        onScroll={onScroll}
+        tabs={TABS}
+        renderHeaderBar={() => <HeaderBar scrollValue={scrollValue} />}
+        showsVerticalScrollIndicator={false}>
+        {TABS.map((tab, i) => (
+          <View key={i} style={[styles.contentContainer, { height: windowHeight }]}>
+            <Text style={[screenStyles.text, styles.contentText]}>
+              {tab.description}
+            </Text>
+          </View>
+        ))}
+      </TabbedHeaderPager>
+      <StatusBar barStyle="light-content" backgroundColor="black" translucent />
+    </>
+  );
+};
 
 const styles = StyleSheet.create({
+  titleStyle: {
+    backgroundColor: colors.semitransparentBlack,
+    color: colors.white,
+    fontFamily: 'AvertaStd-Semibold',
+    fontSize: 40,
+    padding: 10,
+  },
   tabTextContainerStyle: {
-    backgroundColor: 'transparent',
+    backgroundColor: colors.transparent,
     borderRadius: 18,
   },
   tabTextContainerActiveStyle: {
-    backgroundColor: 'orange',
+    backgroundColor: colors.activeOrange,
   },
   tabText: {
-    color: 'white',
+    color: colors.white,
+    fontFamily: 'AvertaStd-Semibold',
     fontSize: 16,
-    fontWeight: 'bold',
     lineHeight: 20,
     paddingHorizontal: 12,
     paddingVertical: 8,
   },
   tabTextActiveStyle: {
-    color: 'black',
+    color: colors.black,
+    fontFamily: 'AvertaStd-Semibold',
     fontSize: 16,
-    fontWeight: 'bold',
     lineHeight: 20,
     paddingHorizontal: 12,
     paddingVertical: 8,
@@ -103,118 +219,12 @@ const styles = StyleSheet.create({
   tabsContainerStyle: {
     paddingHorizontal: 10,
   },
-})
-
-return (
-  <TabbedHeaderPager
-    //...
-    tabsContainerBackgroundColor={colors.black}
-    tabTextContainerStyle={styles.tabTextContainerStyle}
-    tabTextContainerActiveStyle={styles.tabTextContainerActiveStyle}
-    tabTextStyle={styles.tabText}
-    tabTextActiveStyle={styles.tabTextActiveStyle}
-    tabWrapperStyle={styles.tabWrapperStyle}
-    tabsContainerStyle={styles.tabsContainerStyle}
-    //...
-  >
-    {/** content */}
-  </TabbedHeaderPager>
-)
-```
-
-## Custom header foreground
-
-Instead of setting header color by `backgroundColor` prop, we can use `backgroundImage` and pass an image.
-In the TabbarHeader example there is a small avatar image and title below, we can set the first one by passing
-image to the `foregroundImage` prop.
-To customise title, we can pass it by title prop `title="Baby Yoda"` and then pass styles by `titleStyle` prop.
-
-```tsx
-const styles = StyleSheet.create({
-  titleStyle: {
-    color: 'white',
-    fontWeight: 'bold',
+  contentContainer: {
+    backgroundColor: colors.white,
     padding: 10,
-    fontSize: 40,
-    backgroundColor: 'rgba(0,0,0,0.6)'
-  }
-})
-
-return (
-  <TabbedHeaderPager
-    // ...
-    backgroundImage={{
-      uri: 'https://yoda.jpeg',
-    }}
-    title="Baby Yoda"
-    titleStyle={styles.titleStyle}
-    foregroundImage={{
-      uri: 'https://starwars.png',
-    }}
-    // ...
-  >
-    {/** content */}
-  </TabbedHeaderPager>
-)
+  },
+  contentText: {
+    fontSize: 16,
+  },
+});
 ```
-## Custom Header component
-
-Instead of passing your own logo to the header, you can create component and pass it to the `renderHeaderBar` prop. It allows you to create back/close button and create custom animations
-
-In the example below there is custom header containing close button which is visible all the time, 
-and the title displayed on header, visible only when the header is in closed state.
-
-In order to do this, we save vertical content offset in a Reanimated's shared value and then use it to interpolate opacity value of the View with the title.
-
-```tsx
-const HeaderBar = ({ scrollValue }) => {
-  //...
-
-  const animatedStyle = useAnimatedStyle(() => {
-    return { opacity: interpolate(scrollValue.value, [0, 60, 90], [0, 0, 1], Extrapolate.CLAMP) };
-  });
-
-  return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={...}>
-      <View style={...}>
-        <TouchableOpacity onPress={...}>
-          <Image
-            style={...}
-            resizeMode="contain"
-            source={{
-              uri: 'https://close.png',
-            }}
-          />
-        </TouchableOpacity>
-        <Animated.View style={animatedStyle}>
-          <Text style={...}>Baby Yoda</Text>
-        </Animated.View>
-      </View>
-    </SafeAreaView>
-  );
-};
-
-const YodaScreen = () => {
-  // ...
-  const scrollValue = useSharedValue(0);
-
-  function onScroll(e: NativeScrollEvent) {
-    'worklet';
-    scrollValue.value = e.contentOffset.y;
-  }
-
-  return (
-    <TabbedHeaderPager
-      // ...
-      onScroll={onScroll}
-      renderHeaderBar={() => <HeaderBar scrollValue={scrollValue} />}
-    >
-      {/** content */}
-    </TabbedHeaderPager>
-  )
-}
-```
-
-## Summary - Full source code
-
-Full source code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/YodaScreen/index.tsx)

--- a/docs/docs/guides/custom-icons.md
+++ b/docs/docs/guides/custom-icons.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 4
+---
+
+# Rendering custom (styled) icons
+
+You can pass just React component to `leftTopIcon` & `rightTopIcon` prop in AvatarHeader or DetailsHeader components.
+
+```tsx
+<AvatarHeaderScrollView
+  leftTopIcon={() => <Image style={styles.customStyle} source={require('./custom-icon.png')} />}
+  rightTopIcon={() => <CustomSvgIcon />}
+  // ...
+>
+  {/** content */}
+</AvatarHeaderScrollView>
+```

--- a/docs/docs/guides/react-navigation-header.md
+++ b/docs/docs/guides/react-navigation-header.md
@@ -1,0 +1,53 @@
+---
+sidebar_position: 5
+---
+
+# React Navigation header and sticky header layout
+
+If react-navigation header inside the screen is used, sticky header component should have `enableSafeAreaTopInset` prop set to `false`, to prevent duplicated margin between react-navigation header and sticky header layout.
+
+Full example code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/TabbedHeaderWithSectionLists.tsx)
+
+```tsx
+const TabbedHeaderWithSectionListsExample: React.FC = () => {
+  const isDarkTheme = useColorScheme() === 'dark';
+
+  return (
+    <>
+      <TabbedHeaderPager
+        contentContainerStyle={[
+          isDarkTheme ? screenStyles.darkBackground : screenStyles.lightBackground,
+        ]}
+        backgroundColor={colors.primaryGreen}
+        containerStyle={screenStyles.stretchContainer}
+        foregroundImage={photosPortraitMe}
+        disableScrollToPosition={true}
+        enableSafeAreaTopInset={false} // <-------------- disable safe are top inset in sticky header
+        rememberTabScrollPosition={false}
+        logo={logo}
+        title={"Mornin' Mark! \nReady for a quiz?"}
+        titleStyle={screenStyles.text}
+        titleTestID={tabbedHeaderTestIDs.title}
+        stickyTabs={false}
+        tabs={QUIZ_TAB_SECTIONS.map((section) => ({
+          title: section.title,
+          testID: section.testID,
+        }))}
+        tabTextStyle={screenStyles.text}
+        showsVerticalScrollIndicator={false}>
+        <View style={styles.content}>
+          <List startIndex={0} />
+        </View>
+        <View style={styles.content}>
+          <List startIndex={1} />
+        </View>
+        <View style={styles.content}>
+          <List startIndex={2} />
+        </View>
+      </TabbedHeaderPager>
+      <StatusBar barStyle="light-content" backgroundColor={colors.primaryGreen} translucent />
+    </>
+  );
+};
+
+```

--- a/docs/docs/headers/avatar-header.md
+++ b/docs/docs/headers/avatar-header.md
@@ -8,53 +8,45 @@ sidebar_position: 4
 
 ## Example usage
 
+Check out AvatarHeader examples for [ScrollView](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/AvatarHeaderScrollViewExample.tsx), [FlatList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/AvatarHeaderFlatListExample.tsx), [SectionList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/AvatarHeaderSectionListExample.tsx) & [FlashList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/AvatarHeaderFlashListExample.tsx)
+
 ```tsx
-import * as React from 'react'
-import {
-  AvatarHeaderScrollView,
-  AvatarHeaderFlatList,
-  AvatarHeaderSectionList,
-} from 'react-native-sticky-parallax-header'
+const AvatarHeaderScrollViewExample: React.FC = () => {
+  const navigation = useNavigation();
 
-export const TestScrollViewScreen = () => (
-  <>
-    <AvatarHeaderScrollView
-      leftTopIcon={require('<path-to-details-left-icon>')}
-      image={{ uri: '<path-to-details-image>' }}
-      backgroundColor="green"
-      subtitle="Details subtitle"
-      title="Details title"
-    >
-      {/** scroll view content */}
-    </AvatarHeaderScrollView>
-  </>
-)
+  function goBack() {
+    navigation.goBack();
+  }
 
-export const TestFlatListScreen = () => (
-  <>
-    <AvatarHeaderFlatList
-      {...flatListProps}
-      leftTopIcon={require('<path-to-details-left-icon>')}
-      image={{ uri: '<path-to-details-image>' }}
-      backgroundColor="green"
-      subtitle="Details subtitle"
-      title="Details title"
-    />
-  </>
-)
+  const isDarkTheme = useColorScheme() === 'dark';
 
-export const TestSectionListScreen = () => (
-  <>
-    <AvatarHeaderSectionList
-      {...sectionListProps}
-      leftTopIcon={require('<path-to-details-left-icon>')}
-      image={{ uri: '<path-to-details-image>' }}
-      backgroundColor="green"
-      subtitle="Details subtitle"
-      title="Details title"
-    />
-  </>
-)
+  return (
+    <>
+      <AvatarHeaderScrollView
+        leftTopIcon={iconCloseWhite}
+        leftTopIconOnPress={goBack}
+        rightTopIcon={IconMenu}
+        contentContainerStyle={[
+          isDarkTheme ? screenStyles.darkBackground : screenStyles.lightBackground,
+        ]}
+        containerStyle={screenStyles.stretchContainer}
+        backgroundColor={Brandon.color}
+        hasBorderRadius
+        image={Brandon.image}
+        subtitle={Brandon.about}
+        title={Brandon.author}
+        titleStyle={screenStyles.text}
+        showsVerticalScrollIndicator={false}>
+        <View style={styles.content}>
+          {Brandon.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+      </AvatarHeaderScrollView>
+      <StatusBar barStyle="light-content" backgroundColor={Brandon.color} translucent />
+    </>
+  );
+};
 ```
 
 ## Props

--- a/docs/docs/headers/avatar-header.md
+++ b/docs/docs/headers/avatar-header.md
@@ -69,6 +69,7 @@ Inherits [SectionListProps](https://reactnative.dev/docs/next/sectionlist#props)
 | backgroundColor | color - `ColorValue` | - |
 | backgroundImage | image source - `ImageSourcePropType` | - |
 | containerStyle | style - `StyleProp<ViewStyle>` | - |
+| enableSafeAreaTopInset | boolean | true |
 | leftTopIcon | render function or image source | - |
 | leftTopIconAccessibilityLabel | string | - |
 | leftTopIconOnPress | function - `() => void` | - |

--- a/docs/docs/headers/custom-header.md
+++ b/docs/docs/headers/custom-header.md
@@ -6,57 +6,7 @@ sidebar_position: 5
 
 ## Example usage
 
-```tsx
-import * as React from 'react';
-import { View } from 'react-native';
-import {
-  StickyHeaderScrollView,
-  useStickyHeaderScrollProps,
-} from 'react-native-sticky-parallax-header';
-
-const PARALLAX_HEIGHT = 330;
-const HEADER_BAR_HEIGHT = 92;
-const SNAP_START_THRESHOLD = 50;
-const SNAP_STOP_THRESHOLD = 330;
-
-const TestScreen = () => {
-  const {
-    onMomentumScrollEnd,
-    onScroll,
-    onScrollEndDrag,
-    scrollHeight,
-    scrollValue,
-    scrollViewRef,
-  } = useStickyHeaderScrollProps({
-    parallaxHeight: PARALLAX_HEIGHT,
-    snapStartThreshold: SNAP_START_THRESHOLD,
-    snapStopThreshold: SNAP_STOP_THRESHOLD,
-    snapToEdge: true,
-  });
-
-  return (
-    <View>
-      {/** render header bar */}
-      <View>
-        <StickyHeaderScrollView
-          ref={scrollViewRef}
-          onScroll={onScroll}
-          onMomentumScrollEnd={onMomentumScrollEnd}
-          onScrollEndDrag={onScrollEndDrag}
-          renderHeader={() => {
-            return (
-              <View style={{ height: scrollHeight }}>
-                {/** render header foreground */}
-              </View>
-            );
-          }}>
-          {/** render scroll view content */}
-        </StickyHeaderScrollView>
-      </View>
-    </View>
-  );
-}
-```
+Check [custom header example](../examples/custom-header.md)
 
 ## Props
 

--- a/docs/docs/headers/details-header.md
+++ b/docs/docs/headers/details-header.md
@@ -75,6 +75,7 @@ Inherits [SectionListProps](https://reactnative.dev/docs/next/sectionlist#props)
 | contentIconNumber | number | - |
 | contentIconNumberStyle | style - `StyleProp<TextStyle>` | - |
 | contentIconNumberTestID | string | - |
+| enableSafeAreaTopInset | boolean | true |
 | leftTopIcon | render function or image source | - |
 | leftTopIconAccessibilityLabel | string | - |
 | leftTopIconOnPress | function - `() => void` | - |

--- a/docs/docs/headers/details-header.md
+++ b/docs/docs/headers/details-header.md
@@ -8,53 +8,47 @@ sidebar_position: 3
 
 ## Example usage
 
+Check out DetailsHeader examples for [ScrollView](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/DetailsHeaderScrollViewExample.tsx), [FlatList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/DetailsHeaderFlatListExample.tsx), [SectionList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/DetailsHeaderSectionListExample.tsx) & [FlashList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/DetailsHeaderFlashListExample.tsx)
+
 ```tsx
-import * as React from 'react'
-import {
-  DetailsHeaderScrollView,
-  DetailsHeaderFlatList,
-  DetailsHeaderSectionList,
-} from 'react-native-sticky-parallax-header'
+const DetailsHeaderScrollViewExample: React.FC = () => {
+  const navigation = useNavigation();
 
-export const TestScrollViewScreen = () => (
-  <>
-    <DetailsHeaderScrollView
-      leftTopIcon={require('<path-to-details-left-icon>')}
-      image={{ uri: '<path-to-details-image>' }}
-      backgroundColor="green"
-      tag="Details type"
-      title="Details title"
-    >
-      {/** scroll view content */}
-    </DetailsHeaderScrollView>
-  </>
-)
+  function goBack() {
+    navigation.goBack();
+  }
 
-export const TestFlatListScreen = () => (
-  <>
-    <DetailsHeaderFlatList
-      {...flatListProps}
-      leftTopIcon={require('<path-to-details-left-icon>')}
-      image={{ uri: '<path-to-details-image>' }}
-      backgroundColor="green"
-      tag="Details type"
-      title="Details title"
-    />
-  </>
-)
+  const isDarkTheme = useColorScheme() === 'dark';
 
-export const TestSectionListScreen = () => (
-  <>
-    <DetailsHeaderSectionList
-      {...sectionListProps}
-      leftTopIcon={require('<path-to-details-left-icon>')}
-      image={{ uri: '<path-to-details-image>' }}
-      backgroundColor="green"
-      tag="Details type"
-      title="Details title"
-    />
-  </>
-)
+  return (
+    <>
+      <DetailsHeaderScrollView
+        leftTopIcon={iconCloseWhite}
+        leftTopIconOnPress={goBack}
+        rightTopIcon={IconMenu}
+        contentContainerStyle={[
+          isDarkTheme ? screenStyles.darkBackground : screenStyles.lightBackground,
+        ]}
+        containerStyle={screenStyles.stretchContainer}
+        contentIcon={CardsBlack}
+        contentIconNumber={10}
+        backgroundColor={Brandon.color}
+        hasBorderRadius
+        image={Brandon.image}
+        tag={Brandon.type}
+        title={Brandon.author}
+        titleStyle={screenStyles.text}
+        showsVerticalScrollIndicator={false}>
+        <View style={styles.content}>
+          {Brandon.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+      </DetailsHeaderScrollView>
+      <StatusBar barStyle="light-content" backgroundColor={Brandon.color} translucent />
+    </>
+  );
+};
 ```
 
 ## Props

--- a/docs/docs/headers/flashlist-headers.md
+++ b/docs/docs/headers/flashlist-headers.md
@@ -12,88 +12,11 @@ To make [FlashList](https://shopify.github.io/flash-list/docs/) work with react-
 
 ## Example usage
 
-```tsx
-import { FlashList } from '@shopify/flash-list'
-import * as React from 'react'
-import {
-  withAvatarHeaderFlashList,
-  withDetailsHeaderFlashList,
-  withTabbedHeaderFlashList,
-} from 'react-native-sticky-parallax-header'
+For full examples check:
 
-type ItemType = { title: string } // Example data type
-type SectionType = string // Example section data type
-
-const AvatarHeaderFlashList = withAvatarHeaderFlashList<ItemType>(FlashList)
-const DetailsHeaderFlashList = withDetailsHeaderFlashList<ItemType>(FlashList)
-const TabbedHeaderFlashList = withTabbedHeaderFlashList<ItemType | SectionType>(FlashList)
-
-export const TestAvatarHeaderFlashListScreen = () => (
-  <>
-    <AvatarHeaderFlashList
-      {...flashListProps}
-      leftTopIcon={require('<path-to-details-left-icon>')}
-      image={{ uri: '<path-to-details-image>' }}
-      backgroundColor="green"
-      subtitle="Details subtitle"
-      title="Details title"
-    />
-  </>
-)
-
-export const TestDetailsHeaderFlashListScreen = () => (
-  <>
-    <DetailsHeaderFlashList
-      {...flashListProps}
-      leftTopIcon={require('<path-to-details-left-icon>')}
-      image={{ uri: '<path-to-details-image>' }}
-      backgroundColor="green"
-      tag="Details type"
-      title="Details title"
-    />
-  </>
-)
-
-const data: (ItemType | SectionType)[] // example data
-
-function isNotEmpty<T>(item: T | null): item is T {
-  return item !== null;
-}
-
-const stickyHeaderIndices = data
-  .map((item, index) => {
-    return typeof item === 'string' ? index : null;
-  })
-  .filter(isNotEmpty);
-
-const tabs = data
-  .map((item) => {
-    return typeof item === 'string' ? item : null;
-  })
-  .filter(isNotEmpty);
-
-export const TestTabbedHeaderFlashListScreen = () => (
-  <>
-    <TabbedHeaderFlashList
-      {...flashListProps}
-      data={data}
-      renderItem={({ item }) => {
-        if (typeof item === 'string') {
-          return // render section header
-        }
-
-        return // render section item
-      }}
-      getItemType={(item) => {
-        return typeof item === 'string' ? 'sectionHeader' : 'row';
-      }}
-      estimatedItemSize={200}
-      stickyHeaderIndices={stickyHeaderIndices}
-      tabs={tabs}
-    />
-  </>
-)
-```
+- [AvatarHeaderFlashList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/AvatarHeaderFlashListExample.tsx)
+- [DetailsHeaderFlashList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/DetailsHeaderFlashListExample.tsx)
+- [TabbedHeaderFlashList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/TabbedHeaderFlashListExample.tsx)
 
 ## Props
 

--- a/docs/docs/headers/tabbed-header-list.md
+++ b/docs/docs/headers/tabbed-header-list.md
@@ -54,6 +54,7 @@ Inherits [SectionListProps](https://reactnative.dev/docs/next/sectionlist#props)
 | backgroundColor | color - `ColorValue` | - |
 | backgroundImage | image source - `ImageSourcePropType` | - |
 | containerStyle | style - `StyleProp<ViewStyle>` | - |
+| enableSafeAreaTopInset | boolean | true |
 | foregroundImage | image source - `ImageSourcePropType` | - |
 | hasBorderRadius | boolean | - |
 | headerHeight | number | 100 |

--- a/docs/docs/headers/tabbed-header-list.md
+++ b/docs/docs/headers/tabbed-header-list.md
@@ -8,35 +8,41 @@ sidebar_position: 2
 
 ## Example usage
 
+Full source code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/TabbedHeaderListExample.tsx).
+
 ```tsx
-import * as React from 'react';
-import { Text, View } from 'react-native';
-import { TabbedHeaderList } from 'react-native-sticky-parallax-header';
-
-const TABBED_SECTION_ITEM_HEIGHT = 100
-
-const TestScreen = () => (
-  <>
-    <TabbedHeaderList
-      keyExtractor={(_, i) => `${i}`}
-      renderItem={({ item }) => <View key={item.title} style={{ height: TABBED_SECTION_ITEM_HEIGHT }}>
-        <Text>{item.description}</Text>
-      </View>}
-      renderSectionHeader={({ section }) => <View style={{ height: TABBED_SECTION_ITEM_HEIGHT }}>
-        <Text>{section.title}</Text>
-      </View>}
-      getItemLayout={(_, index) => ({
-        length: TABBED_SECTION_ITEM_HEIGHT,
-        offset: TABBED_SECTION_ITEM_HEIGHT * index,
-        index,
-      })}
-      sections={TABBED_SECTIONS}
-      tabs={TABBED_SECTIONS.map((tab) => ({ title: tab.title }))}
-    />
-  </>
-)
-
-export default TestScreen
+const TabbedHeaderListExample: React.FC = () => {
+  return (
+    <>
+      <TabbedHeaderList
+        contentContainerStyle={{ backgroundColor: colors.coralPink }}
+        containerStyle={screenStyles.stretchContainer}
+        backgroundColor={colors.coralPink}
+        title="Food delivery app"
+        titleStyle={screenStyles.text}
+        foregroundImage={{ uri: 'https://foodish-api.herokuapp.com/images/samosa/samosa9.jpg' }}
+        parallaxHeight={100}
+        tabs={TABBED_SECTIONS.map(({ title }) => ({ title }))}
+        tabTextStyle={screenStyles.text}
+        sections={TABBED_SECTIONS}
+        tabTextContainerActiveStyle={{ backgroundColor: colors.activeOrange }}
+        keyExtractor={(_, i) => `${i}`}
+        renderItem={({ item }) => <TabbedSectionItem {...item} />}
+        renderSectionHeader={({ section }) => (
+          <TabbedSectionHeader title={section.title} />
+        )}
+        getItemLayout={(_, index) => ({
+          length: TABBED_SECTION_ITEM_HEIGHT,
+          offset: TABBED_SECTION_ITEM_HEIGHT * index,
+          index,
+        })}
+        updateCellsBatchingPeriod={100}
+        showsVerticalScrollIndicator={false}
+      />
+      <StatusBar barStyle="light-content" backgroundColor={colors.coralPink} translucent />
+    </>
+  );
+};
 ```
 
 ## Props

--- a/docs/docs/headers/tabbed-header-pager.md
+++ b/docs/docs/headers/tabbed-header-pager.md
@@ -79,6 +79,7 @@ Inherits [ScrollViewProps](https://reactnative.dev/docs/next/scrollview#props)
 | backgroundImage | image source - `ImageSourcePropType` | - |
 | containerStyle | style - `StyleProp<ViewStyle>` | - |
 | disableScrollToPosition | boolean | - |
+| enableSafeAreaTopInset | boolean | true |
 | foregroundImage | image source - `ImageSourcePropType` | - |
 | hasBorderRadius | boolean | - |
 | headerHeight | number | 100 |

--- a/docs/docs/headers/tabbed-header-pager.md
+++ b/docs/docs/headers/tabbed-header-pager.md
@@ -8,26 +8,65 @@ sidebar_position: 1
 
 ## Example usage
 
+Full source code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/TabbedHeaderPagerExample.tsx).
+
 ```tsx
-import * as React from 'react';
-import { Text, View } from 'react-native';
-import { TabbedHeaderPager } from 'react-native-sticky-parallax-header';
+const TabbedHeaderPagerExample: React.FC = () => {
+  const isDarkTheme = useColorScheme() === 'dark';
 
-const TestScreen = () => (
-  <>
-    <TabbedHeaderPager
-      tabs={TABS.map((tab) => ({ title: tab.title }))}
-    >
-      {TABS.map((tab) => (
-        <View key={tab.title}>
-          <Text>{tab.description}</Text>
+  return (
+    <>
+      <TabbedHeaderPager
+        contentContainerStyle={[
+          isDarkTheme ? screenStyles.darkBackground : screenStyles.lightBackground,
+        ]}
+        containerStyle={screenStyles.stretchContainer}
+        backgroundColor={colors.primaryGreen}
+        foregroundImage={photosPortraitMe}
+        rememberTabScrollPosition
+        logo={logo}
+        title={"Mornin' Mark! \nReady for a quiz?"}
+        titleStyle={screenStyles.text}
+        tabs={TABBED_SECTIONS.map((section) => ({
+          title: section.title,
+        }))}
+        tabTextStyle={screenStyles.text}
+        showsVerticalScrollIndicator={false}>
+        <View style={styles.content}>
+          {Brandon.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
         </View>
-      ))}
-    </TabbedHeaderPager>
-  </>
-)
-
-export default TestScreen
+        <View style={styles.content}>
+          {Ewa.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+        <View style={styles.content}>
+          {Jennifer.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+        <View style={styles.content}>
+          {Brandon.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+        <View style={styles.content}>
+          {Ewa.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+        <View style={styles.content}>
+          {Jennifer.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+      </TabbedHeaderPager>
+      <StatusBar barStyle="light-content" backgroundColor={colors.primaryGreen} translucent />
+    </>
+  );
+};
 ```
 
 ## Props

--- a/docs/docs/introduction/getting-started.md
+++ b/docs/docs/introduction/getting-started.md
@@ -53,20 +53,3 @@ As with primitive components, FlashList can also be customized to create its own
 **Check the live demo on Expo Snack [here](https://snack.expo.dev/@netguru_rnd/sticky-parallax-header-example).**
 
 <div data-snack-id="@netguru_rnd/sticky-parallax-header-example" data-snack-platform="web" data-snack-preview="true" data-snack-theme="light" className="expo-snack"></div>
-
-This is how you can display header in your app:
-
-```tsx
-import * as React from 'react'
-import { DetailsHeaderScrollView } from 'react-native-sticky-parallax-header'
-
-const TestScreen = () => (
-  <>
-    <DetailsHeaderScrollView {...scrollProps} {...detailsHeaderProps}>
-      {/** scroll view content */}
-    </DetailsHeaderScrollView>
-  </>
-)
-
-export default TestScreen
-```

--- a/docs/docs/introduction/installation.md
+++ b/docs/docs/introduction/installation.md
@@ -16,8 +16,14 @@ Library supports react-native version 0.64+
 $ yarn add react-native-sticky-parallax-header@rc
 ```
 
-### Install library's dependencies
+### Prerequisites
 
 ```sh
 yarn add react-native-reanimated react-native-safe-area-context
+```
+
+After installation check Reanimated installation [guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation) and handle Pods installation
+
+```sh
+npx pod-install
 ```

--- a/docs/docs/introduction/installation.md
+++ b/docs/docs/introduction/installation.md
@@ -22,8 +22,7 @@ $ yarn add react-native-sticky-parallax-header@rc
 yarn add react-native-reanimated react-native-safe-area-context
 ```
 
-After installation check Reanimated installation [guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation) and handle Pods installation
-
-```sh
-npx pod-install
-```
+After installation:
+- check Reanimated installation [guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation)
+- handle Pods installation with `npx pod-install`
+- wrap your root component with `SafeAreaProvider` from `react-native-safe-area-context`

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,8 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-rc.1",
-    "@docusaurus/preset-classic": "2.0.0-rc.1",
+    "@docusaurus/core": "2.0.1",
+    "@docusaurus/preset-classic": "2.0.1",
     "@mdx-js/react": "^1.6.22",
     "@svgr/webpack": "^6.3.1",
     "clsx": "^1.2.1",
@@ -26,7 +26,7 @@
     "url-loader": "^4.1.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.0.0-rc.1",
+    "@docusaurus/module-type-aliases": "2.0.1",
     "@tsconfig/docusaurus": "^1.0.6",
     "typescript": "^4.7.4"
   },

--- a/docs/versioned_docs/version-1.0.x/examples/custom-flashlist-header.md
+++ b/docs/versioned_docs/version-1.0.x/examples/custom-flashlist-header.md
@@ -8,3 +8,65 @@ Analogically to [custom headers](./custom-header.md), react-native-sticky-parall
 
 - `useStickyHeaderFlashListScrollProps` equivalent for [`useStickyHeaderScrollProps`](./custom-header.md#scroll-props)
 - `withStickyHeaderFlashList` equivalent for `withStickyHeader`
+
+Full source code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/StickyHeaderFlashListExample.tsx)
+
+```tsx
+const PARALLAX_HEIGHT = 330;
+const HEADER_BAR_HEIGHT = 92;
+const SNAP_START_THRESHOLD = 50;
+const SNAP_STOP_THRESHOLD = 330;
+
+const StickyHeaderFlashList = withStickyHeaderFlashList(FlashList) as (
+  props: StickyHeaderFlashListProps<string> & React.RefAttributes<FlashList<string>>
+) => React.ReactElement;
+
+const StickyHeaderFlashListExample: React.FC = () => {
+  const { width: windowWidth } = useWindowDimensions();
+  const {
+    onMomentumScrollEnd,
+    onScroll,
+    onScrollEndDrag,
+    scrollHeight,
+    scrollValue,
+    scrollViewRef,
+  } = useStickyHeaderFlashListScrollProps({
+    parallaxHeight: PARALLAX_HEIGHT,
+    snapStartThreshold: SNAP_START_THRESHOLD,
+    snapStopThreshold: SNAP_STOP_THRESHOLD,
+    snapToEdge: true,
+  });
+
+  return (
+    <View style={screenStyles.screenContainer}>
+      <View style={[styles.headerBarContainer, { width: windowWidth }]}>
+        <HeaderBar scrollValue={scrollValue} />
+      </View>
+      <View style={screenStyles.stretchContainer}>
+        <StickyHeaderFlashList
+          ref={scrollViewRef}
+          containerStyle={screenStyles.stretchContainer}
+          onScroll={onScroll}
+          onMomentumScrollEnd={onMomentumScrollEnd}
+          onScrollEndDrag={onScrollEndDrag}
+          estimatedItemSize={400}
+          renderItem={({ item }) => {
+            return <Paragraph text={item} />;
+          }}
+          renderTabs={() => <Tabs />}
+          renderHeader={() => {
+            return (
+              <View pointerEvents="box-none" style={{ height: scrollHeight }}>
+                <Foreground scrollValue={scrollValue} />
+              </View>
+            );
+          }}
+          showsVerticalScrollIndicator={false}
+          style={screenStyles.stretch}
+        />
+      </View>
+      <StatusBar barStyle="light-content" backgroundColor={colors.black} translucent />
+    </View>
+  );
+};
+```

--- a/docs/versioned_docs/version-1.0.x/examples/custom-header.md
+++ b/docs/versioned_docs/version-1.0.x/examples/custom-header.md
@@ -6,77 +6,69 @@ sidebar_position: 2
 
 To create custom header layout, you'll have to use `StickyHeader(ScrollView|FlatList|SectionList)` & `useStickyHeaderScrollProps`. If you want to use custom scroll component, instead of `StickyHeader(ScrollView|FlatList|SectionList)`, you can wrap your custom scroll component in `withStickyHeader` HOC.
 
-## Scroll props
+For scroll props use `useStickyHeaderScrollProps` hook, which is responsible for creating "snap effect" behavior.
 
-`useStickyHeaderScrollProps` is a hook responsible for creating "snap effect" behavior
+Props returned from `useStickyHeaderScrollProps` should be passed to sticky header component (`StickyHeader(ScrollView|FlatList|SectionList)` or `withStickyHeader` decorated scroll component).
 
-```tsx
-const {
-  onMomentumScrollEnd,
-  onScroll,
-  onScrollEndDrag,
-  scrollHeight,
-  scrollValue,
-  scrollViewRef,
-} = useStickyHeaderScrollProps({
-  parallaxHeight: PARALLAX_HEIGHT,
-  snapStartThreshold: SNAP_START_THRESHOLD,
-  snapStopThreshold: SNAP_STOP_THRESHOLD,
-  snapToEdge: true,
-});
-```
-
-Props returned from `useStickyHeaderScrollProps` should be passed to sticky header component (`StickyHeader(ScrollView|FlatList|SectionList)` or `withStickyHeader` decorated scroll component)
-
-```tsx
-<StickyHeaderScrollView
-  ref={scrollViewRef}
-  onScroll={onScroll}
-  onMomentumScrollEnd={onMomentumScrollEnd}
-  onScrollEndDrag={onScrollEndDrag}
-  renderHeader={() => {
-    /** 
-     * If you need, pass `scrollHeight` & `scrollValue` from `useStickyHeaderScrollProps`
-     * 
-     * Remember to add pointerEvents="box-none" and pointerEvents="none" to header components, to make header part scrollable
-     */
-    return (
-      <View pointerEvents="box-none" style={{ height: scrollHeight }}>
-        <Foreground scrollValue={scrollValue} />
-      </View>
-    );
-  }}
-  // ...
-  >
-  {/** content */}
-</StickyHeaderScrollView>
-```
-
-## Display custom header/tabs layout
-
-To display custom header or tabs layout, use `renderHeader` & `renderTabs` props
-
-```tsx
-<StickyHeaderScrollView
-  // ...
-  renderHeader={() => {
-    /** 
-     * If you need, pass `scrollHeight` & `scrollValue` from `useStickyHeaderScrollProps`
-     * 
-     * Remember to add pointerEvents="box-none" and pointerEvents="none" to header components, to make header part scrollable
-     */
-    return (
-      <View pointerEvents="box-none" style={{ height: scrollHeight }}>
-        <Foreground scrollValue={scrollValue} />
-      </View>
-    );
-  }}
-  // ...
-  >
-  {/** content */}
-</StickyHeaderScrollView>
-```
-
-## Summary - Full source code
+To display custom header or tabs layout, use `renderHeader` & `renderTabs` props.
 
 Full source code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/SimsScreen/index.tsx)
+
+```tsx
+const PARALLAX_HEIGHT = 330;
+const HEADER_BAR_HEIGHT = 92;
+const SNAP_START_THRESHOLD = 50;
+const SNAP_STOP_THRESHOLD = 330;
+
+const SimsScreen: React.FC = () => {
+  const { width: windowWidth } = useWindowDimensions();
+  const {
+    onMomentumScrollEnd,
+    onScroll,
+    onScrollEndDrag,
+    scrollHeight,
+    scrollValue,
+    scrollViewRef,
+    // useStickyHeaderScrollProps is generic and need to know
+    // which component (ScrollView, FlatList<ItemT> or SectionList<ItemT, SectionT>)
+    // will be enhanced with sticky scroll props
+  } = useStickyHeaderScrollProps<ScrollView>({
+    parallaxHeight: PARALLAX_HEIGHT,
+    snapStartThreshold: SNAP_START_THRESHOLD,
+    snapStopThreshold: SNAP_STOP_THRESHOLD,
+    snapToEdge: true,
+  });
+
+  return (
+    <View style={screenStyles.screenContainer}>
+      <View style={[styles.headerBarContainer, { width: windowWidth }]}>
+        <HeaderBar scrollValue={scrollValue} />
+      </View>
+      <View style={screenStyles.stretchContainer}>
+        <StickyHeaderScrollView
+          ref={scrollViewRef}
+          containerStyle={screenStyles.stretchContainer}
+          onScroll={onScroll}
+          onMomentumScrollEnd={onMomentumScrollEnd}
+          onScrollEndDrag={onScrollEndDrag}
+          renderHeader={() => {
+            return (
+              <View pointerEvents="box-none" style={{ height: scrollHeight }}>
+                <Foreground scrollValue={scrollValue} />
+              </View>
+            );
+          }}
+          showsVerticalScrollIndicator={false}
+          style={screenStyles.stretch}>
+          <SafeAreaView edges={['left', 'right', 'bottom']} style={styles.content}>
+            <Text style={screenStyles.text}>
+              {text}
+            </Text>
+          </SafeAreaView>
+        </StickyHeaderScrollView>
+      </View>
+      <StatusBar barStyle="light-content" backgroundColor={colors.black} translucent />
+    </View>
+  );
+};
+```

--- a/docs/versioned_docs/version-1.0.x/examples/custom-tabbed-header.md
+++ b/docs/versioned_docs/version-1.0.x/examples/custom-tabbed-header.md
@@ -6,25 +6,88 @@ sidebar_position: 1
 
 ## Tabbed Header Customisation
 
-Example of custom Tabbar Header styling. Whole source code can be found in the summary of this page.
-
 ![Tabbed Header Gif](@site/static/img/assets/readme_yoda.gif)
 
 ## Custom scrollable tabs
 
 To change tabs to your custom ones, pass `tabs` prop to `TabbedHeaderPager` component, where
-`title` is your tab name and then render each tab as a child of `TabbedHeaderPager`:
+`title` is your tab name and then render each tab as a child of `TabbedHeaderPager`
+
+## Custom tab styling
+
+When It comes to tab styling, in TabbedHeader provides following props:
+
+`tabTextStyle` and `tabTextActiveStyle` to pass styles for tab text whether is inactive or active
+
+`tabTextContainerStyle` and `tabTextContainerActiveStyle` to pass styles for tab containers
+
+`tabsContainerBackgroundColor` responsible for backgroundColor of tab bar
+
+`tabWrapperStyle` to pass style for single tab wrapper eg. to change vertical padding
+
+`tabsContainerStyle` to pass style for whole tab bar container eg. to change horizontal padding
+
+## Custom header foreground
+
+Instead of setting header color by `backgroundColor` prop, we can use `backgroundImage` and pass an image.
+
+In the TabbarHeader example there is a small avatar image and title below, we can set the first one by passing
+image to the `foregroundImage` prop.
+
+To customise title, we can pass it by title prop `title="Baby Yoda"` and then pass styles by `titleStyle` prop.
+
+## Custom Header component
+
+Instead of passing your own logo to the header, you can create component and pass it to the `renderHeaderBar` prop. It allows you to create back/close button and create custom animations
+
+In the example below there is custom header containing close button which is visible all the time, 
+and the title displayed on header, visible only when the header is in closed state.
+
+In order to do this, we save vertical content offset in a Reanimated's shared value and then use it to interpolate opacity value of the View with the title.
+
+## Example
+
+Full source code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/YodaScreen/index.tsx).
 
 ```tsx
 const text = {
-  biography: `The bounty hunter known as "the Mandalorian" was dispatched by "the Client" and Imperial Dr. Pershing to capture the Child alive, however the Client would allow the Mandalorian to return the Child dead for a lower price. ...`,
+  biography: `The bounty hunter known as "the Mandalorian" was dispatched by "the Client" and Imperial Dr. Pershing to capture the Child alive, however the Client would allow the Mandalorian to return the Child dead for a lower price.
+  The assassin droid IG-11 was also dispatched to terminate him. After working together to storm the encampment the infant was being held in, the Mandalorian and IG-11 found the Child. IG-11 then attempted to terminate the Child. The Mandalorian shot the droid before the he was able to assassinate the Child.
+  Shortly after, the Mandalorian took the Child back to his ship. On the way they were attacked by a trio of Trandoshan bounty hunters, who attempted to kill the Child. After the Mandalorian defeated them, he and the Child camped out in the desert for the night. While the Mandalorian sat by the fire, the Child ate one of the creatures moving around nearby. He then approached the bounty hunter and attempted to use the Force to heal one of the Mandalorian's wounds. The Mandalorian stopped him and placed him back into his pod. The next day, the pair made it to the Razor Crest only to find it being scavenged by Jawas. The Mandalorian attacked their sandcrawler for the scavenged parts and attempted to climb it while the Child followed in his pod. However, the Mandalorian was knocked down to the ground`,
   powers:
-    'Grogu was able to harness the mystical energies of the Force on account of being Force-sensitive. One notable display of his power was when he telekinetically lifted a giant mudhorn into the air for a brief time to save Djarin from the charging beast. ...',
+    'Grogu was able to harness the mystical energies of the Force on account of being Force-sensitive. One notable display of his power was when he telekinetically lifted a giant mudhorn into the air for a brief time to save Djarin from the charging beast. However, performing this feat was very strenuous for Grogu as he subsequently fell unconscious for several hours afterward. He could also use the Force when he became angry, such as when he telekinetically strangled Cara Dune because he believed she was harming Djarin while they were arm-wrestling. He later revealed the ability to heal serious injuries and even cure poisoning by touching the injury and then using the Force, though the act, much like levitating the mudhorn, was incredibly draining. In another notable display of telekinesis, Grogu created a strong barrier using the Force to protect his companions by both blocking and redirecting a stream of fire from an attacking Incinerator trooper.',
   appearances: `
   Star Wars: Galaxy of Heroes
   Star Wars: Squadrons (as toy) (DLC)
   The-Mandalorian-logo.png The Mandalorian - "Chapter 1: The Mandalorian" (First appearance)
-  ...`.trim(),
+  The Mandalorian: Season 1: Volume 1
+  Star Wars: The Mandalorian Junior Novel
+  The Mandalorian 1
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 2: The Child"
+  The Mandalorian 2
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 3: The Sin"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 4: Sanctuary"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 5: The Gunslinger"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 6: The Prisoner"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 7: The Reckoning"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 8: Redemption"
+  The Mandalorian: A Clan of Two
+  The Mandalorian: Magnetic Fun
+  The Mandalorian: This is the Way
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 9: The Marshal"
+  Star Wars: The Mandalorian Season 2 Junior Novel
+  The Mandalorian: The Path of the Force
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 10: The Passenger"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 11: The Heiress"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 12: The Siege"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 13: The Jedi" (First identified as Grogu)
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 14: The Tragedy"
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 15: The Believer" (Mentioned only)
+  The-Mandalorian-logo.png The Mandalorian - "Chapter 16: The Rescue"
+  The Book of Boba Fett logo.png The Book of Boba Fett - "Chapter 5: Return of the Mandalorian" (Mentioned only)
+  The Book of Boba Fett logo.png The Book of Boba Fett - "Chapter 6: From the Desert Comes a Stranger"
+  The Book of Boba Fett logo.png The Book of Boba Fett - "Chapter 7: In the Name of Honor"
+  `.trim(),
 };
 
 const TABS = [
@@ -42,56 +105,110 @@ const TABS = [
   },
 ];
 
-return (
-  <TabbedHeaderPager
-    //...
-    tabs={TABS}
-    //...
-  >
-    {TABS.map((tab, i) => (
-      <View key={i} style={...}>
-        <Text style={...}>{tab.description}</Text>
+const HeaderBar = ({ scrollValue }) => {
+  const navigation = useNavigation();
+  const goBack = React.useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return { opacity: interpolate(scrollValue.value, [0, 60, 90], [0, 0, 1], Extrapolate.CLAMP) };
+  });
+
+  return (
+    <SafeAreaView edges={['top', 'left', 'right']} style={styles.headerContainer}>
+      <View style={styles.headerWrapper}>
+        <TouchableOpacity onPress={goBack}>
+          <Image
+            style={styles.headerImage}
+            resizeMode="contain"
+            source={{
+              uri: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/VisualEditor_-_Icon_-_Close_-_white.svg/1200px-VisualEditor_-_Icon_-_Close_-_white.svg.png',
+            }}
+          />
+        </TouchableOpacity>
+        <Animated.View style={animatedStyle}>
+          <Text style={styles.headerText}>
+            Baby Yoda
+          </Text>
+        </Animated.View>
       </View>
-    ))}
-  </TabbedHeaderPager>
-)
-```
+    </SafeAreaView>
+  );
+};
 
-## Custom tab styling
+const YodaScreen: React.FC = () => {
+  const { height: windowHeight } = useWindowDimensions();
+  const scrollValue = useSharedValue(0);
 
-When It comes to tab styling, in TabbedHeader provides following props:
+  function onScroll(e: NativeScrollEvent) {
+    'worklet';
+    scrollValue.value = e.contentOffset.y;
+  }
 
-`tabTextStyle` and `tabTextActiveStyle` to pass styles for tab text whether is inactive or active
+  return (
+    <>
+      <TabbedHeaderPager
+        containerStyle={screenStyles.stretchContainer}
+        backgroundImage={{
+          uri: 'https://miro.medium.com/max/1200/1*mk1-6aYaf_Bes1E3Imhc0A.jpeg',
+        }}
+        title="Baby Yoda"
+        titleStyle={styles.titleStyle}
+        foregroundImage={{
+          uri: 'https://cdn.iconscout.com/icon/free/png-256/starwars-6-569425.png',
+        }}
+        tabsContainerBackgroundColor={colors.black}
+        tabTextContainerStyle={styles.tabTextContainerStyle}
+        tabTextContainerActiveStyle={styles.tabTextContainerActiveStyle}
+        tabTextStyle={styles.tabText}
+        tabTextActiveStyle={styles.tabTextActiveStyle}
+        tabWrapperStyle={styles.tabWrapperStyle}
+        tabsContainerStyle={styles.tabsContainerStyle}
+        onScroll={onScroll}
+        tabs={TABS}
+        renderHeaderBar={() => <HeaderBar scrollValue={scrollValue} />}
+        showsVerticalScrollIndicator={false}>
+        {TABS.map((tab, i) => (
+          <View key={i} style={[styles.contentContainer, { height: windowHeight }]}>
+            <Text style={[screenStyles.text, styles.contentText]}>
+              {tab.description}
+            </Text>
+          </View>
+        ))}
+      </TabbedHeaderPager>
+      <StatusBar barStyle="light-content" backgroundColor="black" translucent />
+    </>
+  );
+};
 
-`tabTextContainerStyle` and `tabTextContainerActiveStyle` to pass styles for tab containers
-
-`tabsContainerBackgroundColor` responsible for backgroundColor of tab bar
-
-`tabWrapperStyle` to pass style for single tab wrapper eg. to change vertical padding
-
-`tabsContainerStyle` to pass style for whole tab bar container eg. to change horizontal padding
-
-```tsx
 const styles = StyleSheet.create({
+  titleStyle: {
+    backgroundColor: colors.semitransparentBlack,
+    color: colors.white,
+    fontFamily: 'AvertaStd-Semibold',
+    fontSize: 40,
+    padding: 10,
+  },
   tabTextContainerStyle: {
-    backgroundColor: 'transparent',
+    backgroundColor: colors.transparent,
     borderRadius: 18,
   },
   tabTextContainerActiveStyle: {
-    backgroundColor: 'orange',
+    backgroundColor: colors.activeOrange,
   },
   tabText: {
-    color: 'white',
+    color: colors.white,
+    fontFamily: 'AvertaStd-Semibold',
     fontSize: 16,
-    fontWeight: 'bold',
     lineHeight: 20,
     paddingHorizontal: 12,
     paddingVertical: 8,
   },
   tabTextActiveStyle: {
-    color: 'black',
+    color: colors.black,
+    fontFamily: 'AvertaStd-Semibold',
     fontSize: 16,
-    fontWeight: 'bold',
     lineHeight: 20,
     paddingHorizontal: 12,
     paddingVertical: 8,
@@ -102,118 +219,12 @@ const styles = StyleSheet.create({
   tabsContainerStyle: {
     paddingHorizontal: 10,
   },
-})
-
-return (
-  <TabbedHeaderPager
-    //...
-    tabsContainerBackgroundColor={colors.black}
-    tabTextContainerStyle={styles.tabTextContainerStyle}
-    tabTextContainerActiveStyle={styles.tabTextContainerActiveStyle}
-    tabTextStyle={styles.tabText}
-    tabTextActiveStyle={styles.tabTextActiveStyle}
-    tabWrapperStyle={styles.tabWrapperStyle}
-    tabsContainerStyle={styles.tabsContainerStyle}
-    //...
-  >
-    {/** content */}
-  </TabbedHeaderPager>
-)
-```
-
-## Custom header foreground
-
-Instead of setting header color by `backgroundColor` prop, we can use `backgroundImage` and pass an image.
-In the TabbarHeader example there is a small avatar image and title below, we can set the first one by passing
-image to the `foregroundImage` prop.
-To customise title, we can pass it by title prop `title="Baby Yoda"` and then pass styles by `titleStyle` prop.
-
-```tsx
-const styles = StyleSheet.create({
-  titleStyle: {
-    color: 'white',
-    fontWeight: 'bold',
+  contentContainer: {
+    backgroundColor: colors.white,
     padding: 10,
-    fontSize: 40,
-    backgroundColor: 'rgba(0,0,0,0.6)'
-  }
-})
-
-return (
-  <TabbedHeaderPager
-    // ...
-    backgroundImage={{
-      uri: 'https://yoda.jpeg',
-    }}
-    title="Baby Yoda"
-    titleStyle={styles.titleStyle}
-    foregroundImage={{
-      uri: 'https://starwars.png',
-    }}
-    // ...
-  >
-    {/** content */}
-  </TabbedHeaderPager>
-)
+  },
+  contentText: {
+    fontSize: 16,
+  },
+});
 ```
-## Custom Header component
-
-Instead of passing your own logo to the header, you can create component and pass it to the `renderHeaderBar` prop. It allows you to create back/close button and create custom animations
-
-In the example below there is custom header containing close button which is visible all the time, 
-and the title displayed on header, visible only when the header is in closed state.
-
-In order to do this, we save vertical content offset in a Reanimated's shared value and then use it to interpolate opacity value of the View with the title.
-
-```tsx
-const HeaderBar = ({ scrollValue }) => {
-  //...
-
-  const animatedStyle = useAnimatedStyle(() => {
-    return { opacity: interpolate(scrollValue.value, [0, 60, 90], [0, 0, 1], Extrapolate.CLAMP) };
-  });
-
-  return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={...}>
-      <View style={...}>
-        <TouchableOpacity onPress={...}>
-          <Image
-            style={...}
-            resizeMode="contain"
-            source={{
-              uri: 'https://close.png',
-            }}
-          />
-        </TouchableOpacity>
-        <Animated.View style={animatedStyle}>
-          <Text style={...}>Baby Yoda</Text>
-        </Animated.View>
-      </View>
-    </SafeAreaView>
-  );
-};
-
-const YodaScreen = () => {
-  // ...
-  const scrollValue = useSharedValue(0);
-
-  function handleScroll(e: NativeScrollEvent) {
-    'worklet';
-    scrollValue.value = e.contentOffset.y;
-  }
-
-  return (
-    <TabbedHeaderPager
-      // ...
-      onScroll={handleScroll}
-      renderHeaderBar={() => <HeaderBar scrollValue={scrollValue} />}
-    >
-      {/** content */}
-    </TabbedHeaderPager>
-  )
-}
-```
-
-## Summary - Full source code
-
-Full source code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/YodaScreen/index.tsx)

--- a/docs/versioned_docs/version-1.0.x/guides/custom-icons.md
+++ b/docs/versioned_docs/version-1.0.x/guides/custom-icons.md
@@ -1,0 +1,17 @@
+---
+sidebar_position: 4
+---
+
+# Rendering custom (styled) icons
+
+You can pass just React component to `leftTopIcon` & `rightTopIcon` prop in AvatarHeader or DetailsHeader components.
+
+```tsx
+<AvatarHeaderScrollView
+  leftTopIcon={() => <Image style={styles.customStyle} source={require('./custom-icon.png')} />}
+  rightTopIcon={() => <CustomSvgIcon />}
+  // ...
+>
+  {/** content */}
+</AvatarHeaderScrollView>
+```

--- a/docs/versioned_docs/version-1.0.x/guides/react-navigation-header.md
+++ b/docs/versioned_docs/version-1.0.x/guides/react-navigation-header.md
@@ -1,0 +1,53 @@
+---
+sidebar_position: 5
+---
+
+# React Navigation header and sticky header layout
+
+If react-navigation header inside the screen is used, sticky header component should have `enableSafeAreaTopInset` prop set to `false`, to prevent duplicated margin between react-navigation header and sticky header layout.
+
+Full example code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/TabbedHeaderWithSectionLists.tsx)
+
+```tsx
+const TabbedHeaderWithSectionListsExample: React.FC = () => {
+  const isDarkTheme = useColorScheme() === 'dark';
+
+  return (
+    <>
+      <TabbedHeaderPager
+        contentContainerStyle={[
+          isDarkTheme ? screenStyles.darkBackground : screenStyles.lightBackground,
+        ]}
+        backgroundColor={colors.primaryGreen}
+        containerStyle={screenStyles.stretchContainer}
+        foregroundImage={photosPortraitMe}
+        disableScrollToPosition={true}
+        enableSafeAreaTopInset={false} // <-------------- disable safe are top inset in sticky header
+        rememberTabScrollPosition={false}
+        logo={logo}
+        title={"Mornin' Mark! \nReady for a quiz?"}
+        titleStyle={screenStyles.text}
+        titleTestID={tabbedHeaderTestIDs.title}
+        stickyTabs={false}
+        tabs={QUIZ_TAB_SECTIONS.map((section) => ({
+          title: section.title,
+          testID: section.testID,
+        }))}
+        tabTextStyle={screenStyles.text}
+        showsVerticalScrollIndicator={false}>
+        <View style={styles.content}>
+          <List startIndex={0} />
+        </View>
+        <View style={styles.content}>
+          <List startIndex={1} />
+        </View>
+        <View style={styles.content}>
+          <List startIndex={2} />
+        </View>
+      </TabbedHeaderPager>
+      <StatusBar barStyle="light-content" backgroundColor={colors.primaryGreen} translucent />
+    </>
+  );
+};
+
+```

--- a/docs/versioned_docs/version-1.0.x/headers/avatar-header.md
+++ b/docs/versioned_docs/version-1.0.x/headers/avatar-header.md
@@ -8,47 +8,45 @@ sidebar_position: 4
 
 ## Example usage
 
+Check out AvatarHeader examples for [ScrollView](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/AvatarHeaderScrollViewExample.tsx), [FlatList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/AvatarHeaderFlatListExample.tsx), [SectionList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/AvatarHeaderSectionListExample.tsx) & [FlashList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/AvatarHeaderFlashListExample.tsx)
+
 ```tsx
-import * as React from 'react'
-import {
-  AvatarHeaderScrollView,
-  AvatarHeaderFlatList,
-  AvatarHeaderSectionList,
-} from 'react-native-sticky-parallax-header'
+const AvatarHeaderScrollViewExample: React.FC = () => {
+  const navigation = useNavigation();
 
-export const TestScrollViewScreen = () => (
-  <AvatarHeaderScrollView
-    leftTopIcon={require('<path-to-details-left-icon>')}
-    image={{ uri: '<path-to-details-image>' }}
-    backgroundColor="green"
-    subtitle="Details subtitle"
-    title="Details title"
-  >
-    {/** scroll view content */}
-  </AvatarHeaderScrollView>
-)
+  function goBack() {
+    navigation.goBack();
+  }
 
-export const TestFlatListScreen = () => (
-  <AvatarHeaderFlatList
-    {...flatListProps}
-    leftTopIcon={require('<path-to-details-left-icon>')}
-    image={{ uri: '<path-to-details-image>' }}
-    backgroundColor="green"
-    subtitle="Details subtitle"
-    title="Details title"
-  />
-)
+  const isDarkTheme = useColorScheme() === 'dark';
 
-export const TestSectionListScreen = () => (
-  <AvatarHeaderSectionList
-    {...sectionListProps}
-    leftTopIcon={require('<path-to-details-left-icon>')}
-    image={{ uri: '<path-to-details-image>' }}
-    backgroundColor="green"
-    subtitle="Details subtitle"
-    title="Details title"
-  />
-)
+  return (
+    <>
+      <AvatarHeaderScrollView
+        leftTopIcon={iconCloseWhite}
+        leftTopIconOnPress={goBack}
+        rightTopIcon={IconMenu}
+        contentContainerStyle={[
+          isDarkTheme ? screenStyles.darkBackground : screenStyles.lightBackground,
+        ]}
+        containerStyle={screenStyles.stretchContainer}
+        backgroundColor={Brandon.color}
+        hasBorderRadius
+        image={Brandon.image}
+        subtitle={Brandon.about}
+        title={Brandon.author}
+        titleStyle={screenStyles.text}
+        showsVerticalScrollIndicator={false}>
+        <View style={styles.content}>
+          {Brandon.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+      </AvatarHeaderScrollView>
+      <StatusBar barStyle="light-content" backgroundColor={Brandon.color} translucent />
+    </>
+  );
+};
 ```
 
 ## Props

--- a/docs/versioned_docs/version-1.0.x/headers/avatar-header.md
+++ b/docs/versioned_docs/version-1.0.x/headers/avatar-header.md
@@ -69,6 +69,7 @@ Inherits [SectionListProps](https://reactnative.dev/docs/next/sectionlist#props)
 | backgroundColor | color - `ColorValue` | - |
 | backgroundImage | image source - `ImageSourcePropType` | - |
 | containerStyle | style - `StyleProp<ViewStyle>` | - |
+| enableSafeAreaTopInset | boolean | true |
 | leftTopIcon | render function or image source | - |
 | leftTopIconAccessibilityLabel | string | - |
 | leftTopIconOnPress | function - `() => void` | - |

--- a/docs/versioned_docs/version-1.0.x/headers/custom-header.md
+++ b/docs/versioned_docs/version-1.0.x/headers/custom-header.md
@@ -6,57 +6,7 @@ sidebar_position: 5
 
 ## Example usage
 
-```tsx
-import * as React from 'react';
-import { View } from 'react-native';
-import {
-  StickyHeaderScrollView,
-  useStickyHeaderScrollProps,
-} from 'react-native-sticky-parallax-header';
-
-const PARALLAX_HEIGHT = 330;
-const HEADER_BAR_HEIGHT = 92;
-const SNAP_START_THRESHOLD = 50;
-const SNAP_STOP_THRESHOLD = 330;
-
-const TestScreen = () => {
-  const {
-    onMomentumScrollEnd,
-    onScroll,
-    onScrollEndDrag,
-    scrollHeight,
-    scrollValue,
-    scrollViewRef,
-  } = useStickyHeaderScrollProps({
-    parallaxHeight: PARALLAX_HEIGHT,
-    snapStartThreshold: SNAP_START_THRESHOLD,
-    snapStopThreshold: SNAP_STOP_THRESHOLD,
-    snapToEdge: true,
-  });
-
-  return (
-    <View>
-      {/** render header bar */}
-      <View>
-        <StickyHeaderScrollView
-          ref={scrollViewRef}
-          onScroll={onScroll}
-          onMomentumScrollEnd={onMomentumScrollEnd}
-          onScrollEndDrag={onScrollEndDrag}
-          renderHeader={() => {
-            return (
-              <View style={{ height: scrollHeight }}>
-                {/** render header foreground */}
-              </View>
-            );
-          }}>
-          {/** render scroll view content */}
-        </StickyHeaderScrollView>
-      </View>
-    </View>
-  );
-}
-```
+Check [custom header example](../examples/custom-header.md)
 
 ## Props
 

--- a/docs/versioned_docs/version-1.0.x/headers/details-header.md
+++ b/docs/versioned_docs/version-1.0.x/headers/details-header.md
@@ -75,6 +75,7 @@ Inherits [SectionListProps](https://reactnative.dev/docs/next/sectionlist#props)
 | contentIconNumber | number | - |
 | contentIconNumberStyle | style - `StyleProp<TextStyle>` | - |
 | contentIconNumberTestID | string | - |
+| enableSafeAreaTopInset | boolean | true |
 | leftTopIcon | render function or image source | - |
 | leftTopIconAccessibilityLabel | string | - |
 | leftTopIconOnPress | function - `() => void` | - |

--- a/docs/versioned_docs/version-1.0.x/headers/details-header.md
+++ b/docs/versioned_docs/version-1.0.x/headers/details-header.md
@@ -8,47 +8,47 @@ sidebar_position: 3
 
 ## Example usage
 
+Check out DetailsHeader examples for [ScrollView](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/DetailsHeaderScrollViewExample.tsx), [FlatList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/DetailsHeaderFlatListExample.tsx), [SectionList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/DetailsHeaderSectionListExample.tsx) & [FlashList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/DetailsHeaderFlashListExample.tsx)
+
 ```tsx
-import * as React from 'react'
-import {
-  DetailsHeaderScrollView,
-  DetailsHeaderFlatList,
-  DetailsHeaderSectionList,
-} from 'react-native-sticky-parallax-header'
+const DetailsHeaderScrollViewExample: React.FC = () => {
+  const navigation = useNavigation();
 
-export const TestScrollViewScreen = () => (
-  <DetailsHeaderScrollView
-    leftTopIcon={require('<path-to-details-left-icon>')}
-    image={{ uri: '<path-to-details-image>' }}
-    backgroundColor="green"
-    tag="Details type"
-    title="Details title"
-  >
-    {/** scroll view content */}
-  </DetailsHeaderScrollView>
-)
+  function goBack() {
+    navigation.goBack();
+  }
 
-export const TestFlatListScreen = () => (
-  <DetailsHeaderFlatList
-    {...flatListProps}
-    leftTopIcon={require('<path-to-details-left-icon>')}
-    image={{ uri: '<path-to-details-image>' }}
-    backgroundColor="green"
-    tag="Details type"
-    title="Details title"
-  />
-)
+  const isDarkTheme = useColorScheme() === 'dark';
 
-export const TestSectionListScreen = () => (
-  <DetailsHeaderSectionList
-    {...sectionListProps}
-    leftTopIcon={require('<path-to-details-left-icon>')}
-    image={{ uri: '<path-to-details-image>' }}
-    backgroundColor="green"
-    tag="Details type"
-    title="Details title"
-  />
-)
+  return (
+    <>
+      <DetailsHeaderScrollView
+        leftTopIcon={iconCloseWhite}
+        leftTopIconOnPress={goBack}
+        rightTopIcon={IconMenu}
+        contentContainerStyle={[
+          isDarkTheme ? screenStyles.darkBackground : screenStyles.lightBackground,
+        ]}
+        containerStyle={screenStyles.stretchContainer}
+        contentIcon={CardsBlack}
+        contentIconNumber={10}
+        backgroundColor={Brandon.color}
+        hasBorderRadius
+        image={Brandon.image}
+        tag={Brandon.type}
+        title={Brandon.author}
+        titleStyle={screenStyles.text}
+        showsVerticalScrollIndicator={false}>
+        <View style={styles.content}>
+          {Brandon.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+      </DetailsHeaderScrollView>
+      <StatusBar barStyle="light-content" backgroundColor={Brandon.color} translucent />
+    </>
+  );
+};
 ```
 
 ## Props

--- a/docs/versioned_docs/version-1.0.x/headers/flashlist-headers.md
+++ b/docs/versioned_docs/version-1.0.x/headers/flashlist-headers.md
@@ -12,88 +12,11 @@ To make [FlashList](https://shopify.github.io/flash-list/docs/) work with react-
 
 ## Example usage
 
-```tsx
-import { FlashList } from '@shopify/flash-list'
-import * as React from 'react'
-import {
-  withAvatarHeaderFlashList,
-  withDetailsHeaderFlashList,
-  withTabbedHeaderFlashList,
-} from 'react-native-sticky-parallax-header'
+For full examples check:
 
-type ItemType = { title: string } // Example data type
-type SectionType = string // Example section data type
-
-const AvatarHeaderFlashList = withAvatarHeaderFlashList<ItemType>(FlashList)
-const DetailsHeaderFlashList = withDetailsHeaderFlashList<ItemType>(FlashList)
-const TabbedHeaderFlashList = withTabbedHeaderFlashList<ItemType | SectionType>(FlashList)
-
-export const TestAvatarHeaderFlashListScreen = () => (
-  <>
-    <AvatarHeaderFlashList
-      {...flashListProps}
-      leftTopIcon={require('<path-to-details-left-icon>')}
-      image={{ uri: '<path-to-details-image>' }}
-      backgroundColor="green"
-      subtitle="Details subtitle"
-      title="Details title"
-    />
-  </>
-)
-
-export const TestDetailsHeaderFlashListScreen = () => (
-  <>
-    <DetailsHeaderFlashList
-      {...flashListProps}
-      leftTopIcon={require('<path-to-details-left-icon>')}
-      image={{ uri: '<path-to-details-image>' }}
-      backgroundColor="green"
-      tag="Details type"
-      title="Details title"
-    />
-  </>
-)
-
-const data: (ItemType | SectionType)[] // example data
-
-function isNotEmpty<T>(item: T | null): item is T {
-  return item !== null;
-}
-
-const stickyHeaderIndices = data
-  .map((item, index) => {
-    return typeof item === 'string' ? index : null;
-  })
-  .filter(isNotEmpty);
-
-const tabs = data
-  .map((item) => {
-    return typeof item === 'string' ? item : null;
-  })
-  .filter(isNotEmpty);
-
-export const TestTabbedHeaderFlashListScreen = () => (
-  <>
-    <TabbedHeaderFlashList
-      {...flashListProps}
-      data={data}
-      renderItem={({ item }) => {
-        if (typeof item === 'string') {
-          return // render section header
-        }
-
-        return // render section item
-      }}
-      getItemType={(item) => {
-        return typeof item === 'string' ? 'sectionHeader' : 'row';
-      }}
-      estimatedItemSize={200}
-      stickyHeaderIndices={stickyHeaderIndices}
-      tabs={tabs}
-    />
-  </>
-)
-```
+- [AvatarHeaderFlashList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/AvatarHeaderFlashListExample.tsx)
+- [DetailsHeaderFlashList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/DetailsHeaderFlashListExample.tsx)
+- [TabbedHeaderFlashList](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/TabbedHeaderFlashListExample.tsx)
 
 ## Props
 

--- a/docs/versioned_docs/version-1.0.x/headers/tabbed-header-list.md
+++ b/docs/versioned_docs/version-1.0.x/headers/tabbed-header-list.md
@@ -8,33 +8,41 @@ sidebar_position: 2
 
 ## Example usage
 
+Full source code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/TabbedHeaderListExample.tsx).
+
 ```tsx
-import * as React from 'react';
-import { Text, View } from 'react-native';
-import { TabbedHeaderList } from 'react-native-sticky-parallax-header';
-
-const TABBED_SECTION_ITEM_HEIGHT = 100
-
-const TestScreen = () => (
-  <TabbedHeaderList
-    keyExtractor={(_, i) => `${i}`}
-    renderItem={({ item }) => <View key={item.title} style={{ height: TABBED_SECTION_ITEM_HEIGHT }}>
-      <Text>{item.description}</Text>
-    </View>}
-    renderSectionHeader={({ section }) => <View style={{ height: TABBED_SECTION_ITEM_HEIGHT }}>
-      <Text>{section.title}</Text>
-    </View>}
-    getItemLayout={(_, index) => ({
-      length: TABBED_SECTION_ITEM_HEIGHT,
-      offset: TABBED_SECTION_ITEM_HEIGHT * index,
-      index,
-    })}
-    sections={TABBED_SECTIONS}
-    tabs={TABBED_SECTIONS.map((tab) => ({ title: tab.title }))}
-  />
-)
-
-export default TestScreen
+const TabbedHeaderListExample: React.FC = () => {
+  return (
+    <>
+      <TabbedHeaderList
+        contentContainerStyle={{ backgroundColor: colors.coralPink }}
+        containerStyle={screenStyles.stretchContainer}
+        backgroundColor={colors.coralPink}
+        title="Food delivery app"
+        titleStyle={screenStyles.text}
+        foregroundImage={{ uri: 'https://foodish-api.herokuapp.com/images/samosa/samosa9.jpg' }}
+        parallaxHeight={100}
+        tabs={TABBED_SECTIONS.map(({ title }) => ({ title }))}
+        tabTextStyle={screenStyles.text}
+        sections={TABBED_SECTIONS}
+        tabTextContainerActiveStyle={{ backgroundColor: colors.activeOrange }}
+        keyExtractor={(_, i) => `${i}`}
+        renderItem={({ item }) => <TabbedSectionItem {...item} />}
+        renderSectionHeader={({ section }) => (
+          <TabbedSectionHeader title={section.title} />
+        )}
+        getItemLayout={(_, index) => ({
+          length: TABBED_SECTION_ITEM_HEIGHT,
+          offset: TABBED_SECTION_ITEM_HEIGHT * index,
+          index,
+        })}
+        updateCellsBatchingPeriod={100}
+        showsVerticalScrollIndicator={false}
+      />
+      <StatusBar barStyle="light-content" backgroundColor={colors.coralPink} translucent />
+    </>
+  );
+};
 ```
 
 ## Props

--- a/docs/versioned_docs/version-1.0.x/headers/tabbed-header-list.md
+++ b/docs/versioned_docs/version-1.0.x/headers/tabbed-header-list.md
@@ -54,6 +54,7 @@ Inherits [SectionListProps](https://reactnative.dev/docs/next/sectionlist#props)
 | backgroundColor | color - `ColorValue` | - |
 | backgroundImage | image source - `ImageSourcePropType` | - |
 | containerStyle | style - `StyleProp<ViewStyle>` | - |
+| enableSafeAreaTopInset | boolean | true |
 | foregroundImage | image source - `ImageSourcePropType` | - |
 | hasBorderRadius | boolean | - |
 | headerHeight | number | 100 |

--- a/docs/versioned_docs/version-1.0.x/headers/tabbed-header-pager.md
+++ b/docs/versioned_docs/version-1.0.x/headers/tabbed-header-pager.md
@@ -79,6 +79,7 @@ Inherits [ScrollViewProps](https://reactnative.dev/docs/next/scrollview#props)
 | backgroundImage | image source - `ImageSourcePropType` | - |
 | containerStyle | style - `StyleProp<ViewStyle>` | - |
 | disableScrollToPosition | boolean | - |
+| enableSafeAreaTopInset | boolean | true |
 | foregroundImage | image source - `ImageSourcePropType` | - |
 | hasBorderRadius | boolean | - |
 | headerHeight | number | 100 |

--- a/docs/versioned_docs/version-1.0.x/headers/tabbed-header-pager.md
+++ b/docs/versioned_docs/version-1.0.x/headers/tabbed-header-pager.md
@@ -8,24 +8,65 @@ sidebar_position: 1
 
 ## Example usage
 
+Full source code can be found in [example repo](https://github.com/netguru/sticky-parallax-header/blob/master/example/src/screens/additionalExamples/TabbedHeaderPagerExample.tsx).
+
 ```tsx
-import * as React from 'react';
-import { Text, View } from 'react-native';
-import { TabbedHeaderPager } from 'react-native-sticky-parallax-header';
+const TabbedHeaderPagerExample: React.FC = () => {
+  const isDarkTheme = useColorScheme() === 'dark';
 
-const TestScreen = () => (
-  <TabbedHeaderPager
-    tabs={TABS.map((tab) => ({ title: tab.title }))}
-  >
-    {TABS.map((tab) => (
-      <View key={tab.title}>
-        <Text>{tab.description}</Text>
-      </View>
-    ))}
-  </TabbedHeaderPager>
-)
-
-export default TestScreen
+  return (
+    <>
+      <TabbedHeaderPager
+        contentContainerStyle={[
+          isDarkTheme ? screenStyles.darkBackground : screenStyles.lightBackground,
+        ]}
+        containerStyle={screenStyles.stretchContainer}
+        backgroundColor={colors.primaryGreen}
+        foregroundImage={photosPortraitMe}
+        rememberTabScrollPosition
+        logo={logo}
+        title={"Mornin' Mark! \nReady for a quiz?"}
+        titleStyle={screenStyles.text}
+        tabs={TABBED_SECTIONS.map((section) => ({
+          title: section.title,
+        }))}
+        tabTextStyle={screenStyles.text}
+        showsVerticalScrollIndicator={false}>
+        <View style={styles.content}>
+          {Brandon.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+        <View style={styles.content}>
+          {Ewa.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+        <View style={styles.content}>
+          {Jennifer.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+        <View style={styles.content}>
+          {Brandon.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+        <View style={styles.content}>
+          {Ewa.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+        <View style={styles.content}>
+          {Jennifer.cards.map((data, i, arr) => (
+            <QuizCard data={data} num={i} key={data.question} cardsAmount={arr.length} />
+          ))}
+        </View>
+      </TabbedHeaderPager>
+      <StatusBar barStyle="light-content" backgroundColor={colors.primaryGreen} translucent />
+    </>
+  );
+};
 ```
 
 ## Props
@@ -84,6 +125,7 @@ Inherits [ScrollViewProps](https://reactnative.dev/docs/next/scrollview#props)
 | - | - | - |
 | title | string | - |
 | icon | React Element or render function with isActive param | - |
+| testID | string | - |
 
 ### PagerProps
 

--- a/docs/versioned_docs/version-1.0.x/introduction/getting-started.md
+++ b/docs/versioned_docs/version-1.0.x/introduction/getting-started.md
@@ -53,20 +53,3 @@ As with primitive components, FlashList can also be customized to create its own
 **Check the live demo on Expo Snack [here](https://snack.expo.dev/@netguru_rnd/sticky-parallax-header-example).**
 
 <div data-snack-id="@netguru_rnd/sticky-parallax-header-example" data-snack-platform="web" data-snack-preview="true" data-snack-theme="light" className="expo-snack"></div>
-
-This is how you can display header in your app:
-
-```tsx
-import * as React from 'react'
-import { DetailsHeaderScrollView } from 'react-native-sticky-parallax-header'
-
-const TestScreen = () => (
-  <>
-    <DetailsHeaderScrollView {...scrollProps} {...detailsHeaderProps}>
-      {/** scroll view content */}
-    </DetailsHeaderScrollView>
-  </>
-)
-
-export default TestScreen
-```

--- a/docs/versioned_docs/version-1.0.x/introduction/installation.md
+++ b/docs/versioned_docs/version-1.0.x/introduction/installation.md
@@ -16,8 +16,14 @@ Library supports react-native version 0.64+
 $ yarn add react-native-sticky-parallax-header@rc
 ```
 
-### Install library's dependencies
+### Prerequisites
 
 ```sh
 yarn add react-native-reanimated react-native-safe-area-context
+```
+
+After installation check Reanimated installation [guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation) and handle Pods installation
+
+```sh
+npx pod-install
 ```

--- a/docs/versioned_docs/version-1.0.x/introduction/installation.md
+++ b/docs/versioned_docs/version-1.0.x/introduction/installation.md
@@ -22,8 +22,7 @@ $ yarn add react-native-sticky-parallax-header@rc
 yarn add react-native-reanimated react-native-safe-area-context
 ```
 
-After installation check Reanimated installation [guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation) and handle Pods installation
-
-```sh
-npx pod-install
-```
+After installation:
+- check Reanimated installation [guide](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation)
+- handle Pods installation with `npx pod-install`
+- wrap your root component with `SafeAreaProvider` from `react-native-safe-area-context`

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2384,10 +2384,10 @@
     "@docsearch/css" "3.1.1"
     algoliasearch "^4.0.0"
 
-"@docusaurus/core@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.0.0-rc.1.tgz#828d93d241171565d8947a9ab404091e04759141"
-  integrity sha512-b9FX0Z+EddfQ6wAiNh+Wx4fysKfcvEcWJrZ5USROn3C+EVU5P4luaa8mwWK//O+hTwD9ur7/A44IZ/tWCTAoLQ==
+"@docusaurus/core@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.0.1.tgz#a2b0d653e8f18eacddda4778a46b638dd1f0f45c"
+  integrity sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==
   dependencies:
     "@babel/core" "^7.18.6"
     "@babel/generator" "^7.18.7"
@@ -2399,13 +2399,13 @@
     "@babel/runtime" "^7.18.6"
     "@babel/runtime-corejs3" "^7.18.6"
     "@babel/traverse" "^7.18.8"
-    "@docusaurus/cssnano-preset" "2.0.0-rc.1"
-    "@docusaurus/logger" "2.0.0-rc.1"
-    "@docusaurus/mdx-loader" "2.0.0-rc.1"
+    "@docusaurus/cssnano-preset" "2.0.1"
+    "@docusaurus/logger" "2.0.1"
+    "@docusaurus/mdx-loader" "2.0.1"
     "@docusaurus/react-loadable" "5.5.2"
-    "@docusaurus/utils" "2.0.0-rc.1"
-    "@docusaurus/utils-common" "2.0.0-rc.1"
-    "@docusaurus/utils-validation" "2.0.0-rc.1"
+    "@docusaurus/utils" "2.0.1"
+    "@docusaurus/utils-common" "2.0.1"
+    "@docusaurus/utils-validation" "2.0.1"
     "@slorber/static-site-generator-webpack-plugin" "^4.0.7"
     "@svgr/webpack" "^6.2.1"
     autoprefixer "^10.4.7"
@@ -2461,33 +2461,33 @@
     webpack-merge "^5.8.0"
     webpackbar "^5.0.2"
 
-"@docusaurus/cssnano-preset@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-rc.1.tgz#76bbd7f6912779a0667f8f2fd8fc1a05618a6148"
-  integrity sha512-9/KmQvF+eTlMqUqG6UcXbRgxbGed/8bQInXuKEs+95/jI6jO/3xSzuRwuHHHP0naUvSVWjnNI9jngPrQerXE5w==
+"@docusaurus/cssnano-preset@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.1.tgz#4d0c49338cf3aa88c5bd7cffbf77654db8e1e3b2"
+  integrity sha512-MCJ6rRmlqLmlCsZIoIxOxDb0rYzIPEm9PYpsBW+CGNnbk+x8xK+11hnrxzvXHqDRNpxrq3Kq2jYUmg/DkqE6vg==
   dependencies:
     cssnano-preset-advanced "^5.3.8"
     postcss "^8.4.14"
     postcss-sort-media-queries "^4.2.1"
     tslib "^2.4.0"
 
-"@docusaurus/logger@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-2.0.0-rc.1.tgz#db95e9b15bc243695830a5b791c0eff705ef1b54"
-  integrity sha512-daa3g+SXuO9K60PVMiSUmDEK9Vro+Ed7i7uF8CH6QQJLcNZy/zJc0Xz62eH7ip1x77fmeb6Rg4Us1TqTFc9AbQ==
+"@docusaurus/logger@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/logger/-/logger-2.0.1.tgz#78a940a333d2f654fd9dea24db2c962034d4b1ff"
+  integrity sha512-wIWseCKko1w/WARcDjO3N/XoJ0q/VE42AthP0eNAfEazDjJ94NXbaI6wuUsuY/bMg6hTKGVIpphjj2LoX3g6dA==
   dependencies:
     chalk "^4.1.2"
     tslib "^2.4.0"
 
-"@docusaurus/mdx-loader@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-rc.1.tgz#e78d7d416aacc289f2427c5ccdb9145820acb0cb"
-  integrity sha512-8Fg0c/ceu39knmr7w0dutm7gq3YxKYCqWVS2cB/cPATzChCCNH/AGLfBT6sz/Z4tjVXE+NyREq2pfOFvkhjVXg==
+"@docusaurus/mdx-loader@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.0.1.tgz#cc73690ca5d356687d9e75740560b4159cd5cdb5"
+  integrity sha512-tdNeljdilXCmhbaEND3SAgsqaw/oh7v9onT5yrIrL26OSk2AFwd+MIi4R8jt8vq33M0R4rz2wpknm0fQIkDdvQ==
   dependencies:
     "@babel/parser" "^7.18.8"
     "@babel/traverse" "^7.18.8"
-    "@docusaurus/logger" "2.0.0-rc.1"
-    "@docusaurus/utils" "2.0.0-rc.1"
+    "@docusaurus/logger" "2.0.1"
+    "@docusaurus/utils" "2.0.1"
     "@mdx-js/mdx" "^1.6.22"
     escape-html "^1.0.3"
     file-loader "^6.2.0"
@@ -2502,13 +2502,13 @@
     url-loader "^4.1.1"
     webpack "^5.73.0"
 
-"@docusaurus/module-type-aliases@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-rc.1.tgz#c7839ac15b7712a8d86353a3253918f63ffbea09"
-  integrity sha512-la7D8ggFP8I5nOp/Epl6NqTeDWcbofPVMOaVisRxQbx5iuF9Al+AITbaDgm4CXpFLJACsqhsXD5W4BnKX8ZxfA==
+"@docusaurus/module-type-aliases@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.1.tgz#44d7132297bedae0890695b0e7ebbe14a73e26d1"
+  integrity sha512-f888ylnxHAM/3T8p1lx08+lTc6/g7AweSRfRuZvrVhHXj3Tz/nTTxaP6gPTGkJK7WLqTagpar/IGP6/74IBbkg==
   dependencies:
     "@docusaurus/react-loadable" "5.5.2"
-    "@docusaurus/types" "2.0.0-rc.1"
+    "@docusaurus/types" "2.0.1"
     "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router-config" "*"
@@ -2516,18 +2516,18 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@5.5.2"
 
-"@docusaurus/plugin-content-blog@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-rc.1.tgz#8ae5d5ec2da08c583a057bf2754a5b9278b3eb08"
-  integrity sha512-BVVrAGZujpjS/0rarY2o24rlylRRh2NZuM65kg0JNkkViF79SeEHsepog7IuHyoqGWPm1N/I7LpEp7k+gowZzQ==
+"@docusaurus/plugin-content-blog@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.1.tgz#a37065e18ffd26e022ffb16a21ff28199140729e"
+  integrity sha512-/4ua3iFYcpwgpeYgHnhVGROB/ybnauLH2+rICb4vz/+Gn1hjAmGXVYq1fk8g49zGs3uxx5nc0H5bL9P0g977IQ==
   dependencies:
-    "@docusaurus/core" "2.0.0-rc.1"
-    "@docusaurus/logger" "2.0.0-rc.1"
-    "@docusaurus/mdx-loader" "2.0.0-rc.1"
-    "@docusaurus/types" "2.0.0-rc.1"
-    "@docusaurus/utils" "2.0.0-rc.1"
-    "@docusaurus/utils-common" "2.0.0-rc.1"
-    "@docusaurus/utils-validation" "2.0.0-rc.1"
+    "@docusaurus/core" "2.0.1"
+    "@docusaurus/logger" "2.0.1"
+    "@docusaurus/mdx-loader" "2.0.1"
+    "@docusaurus/types" "2.0.1"
+    "@docusaurus/utils" "2.0.1"
+    "@docusaurus/utils-common" "2.0.1"
+    "@docusaurus/utils-validation" "2.0.1"
     cheerio "^1.0.0-rc.12"
     feed "^4.2.2"
     fs-extra "^10.1.0"
@@ -2538,18 +2538,18 @@
     utility-types "^3.10.0"
     webpack "^5.73.0"
 
-"@docusaurus/plugin-content-docs@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-rc.1.tgz#2dda88166bf21b0eeb3821ef748059b20c8c49f7"
-  integrity sha512-Yk5Hu6uaw3tRplzJnbDygwRhmZ3PCzEXD4SJpBA6cPC73ylfqOEh6qhiU+BWhMTtDXNhY+athk5Kycfk3DW1aQ==
+"@docusaurus/plugin-content-docs@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.1.tgz#4059591b4bff617e744e856ca680674b27c0b98a"
+  integrity sha512-2qeBWRy1EjgnXdwAO6/csDIS1UVNmhmtk/bQ2s9jqjpwM8YVgZ8QVdkxFAMWXgZWDQdwWwdP1rnmoEelE4HknQ==
   dependencies:
-    "@docusaurus/core" "2.0.0-rc.1"
-    "@docusaurus/logger" "2.0.0-rc.1"
-    "@docusaurus/mdx-loader" "2.0.0-rc.1"
-    "@docusaurus/module-type-aliases" "2.0.0-rc.1"
-    "@docusaurus/types" "2.0.0-rc.1"
-    "@docusaurus/utils" "2.0.0-rc.1"
-    "@docusaurus/utils-validation" "2.0.0-rc.1"
+    "@docusaurus/core" "2.0.1"
+    "@docusaurus/logger" "2.0.1"
+    "@docusaurus/mdx-loader" "2.0.1"
+    "@docusaurus/module-type-aliases" "2.0.1"
+    "@docusaurus/types" "2.0.1"
+    "@docusaurus/utils" "2.0.1"
+    "@docusaurus/utils-validation" "2.0.1"
     "@types/react-router-config" "^5.0.6"
     combine-promises "^1.1.0"
     fs-extra "^10.1.0"
@@ -2560,84 +2560,84 @@
     utility-types "^3.10.0"
     webpack "^5.73.0"
 
-"@docusaurus/plugin-content-pages@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-rc.1.tgz#2be82f53d6c77e6aa66787726c30dc60b210e6f8"
-  integrity sha512-FdO79WC5hfWDQu3/CTFLRQzTNc0e5n+HNzavm2MNkSzGV08BFJ6RAkbPbtra5CWef+6iXZav6D/tzv2jDPvLzA==
+"@docusaurus/plugin-content-pages@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.1.tgz#013f2e66f80d19b5c95a2d941d67c7cdb67b7191"
+  integrity sha512-6apSVeJENnNecAH5cm5VnRqR103M6qSI6IuiP7tVfD5H4AWrfDNkvJQV2+R2PIq3bGrwmX4fcXl1x4g0oo7iwA==
   dependencies:
-    "@docusaurus/core" "2.0.0-rc.1"
-    "@docusaurus/mdx-loader" "2.0.0-rc.1"
-    "@docusaurus/types" "2.0.0-rc.1"
-    "@docusaurus/utils" "2.0.0-rc.1"
-    "@docusaurus/utils-validation" "2.0.0-rc.1"
+    "@docusaurus/core" "2.0.1"
+    "@docusaurus/mdx-loader" "2.0.1"
+    "@docusaurus/types" "2.0.1"
+    "@docusaurus/utils" "2.0.1"
+    "@docusaurus/utils-validation" "2.0.1"
     fs-extra "^10.1.0"
     tslib "^2.4.0"
     webpack "^5.73.0"
 
-"@docusaurus/plugin-debug@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-rc.1.tgz#73c06ad08d66810941e456d50b07be008f5235cb"
-  integrity sha512-aOsyYrPMbnsyqHwsVZ+0frrMRtnYqm4eaJpG4sC/6LYAJ07IDRQ9j3GOku2dKr5GsFK1Vx7VlE6ZLwe0MaGstg==
+"@docusaurus/plugin-debug@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-2.0.1.tgz#2b2a473f8e01fd356e32236f753665b48209bcd4"
+  integrity sha512-jpZBT5HK7SWx1LRQyv9d14i44vSsKXGZsSPA2ndth5HykHJsiAj9Fwl1AtzmtGYuBmI+iXQyOd4MAMHd4ZZ1tg==
   dependencies:
-    "@docusaurus/core" "2.0.0-rc.1"
-    "@docusaurus/types" "2.0.0-rc.1"
-    "@docusaurus/utils" "2.0.0-rc.1"
+    "@docusaurus/core" "2.0.1"
+    "@docusaurus/types" "2.0.1"
+    "@docusaurus/utils" "2.0.1"
     fs-extra "^10.1.0"
     react-json-view "^1.21.3"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-google-analytics@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-rc.1.tgz#0136cc7534573ca56e023178ec2bda5c1e89ce71"
-  integrity sha512-f+G8z5OJWfg5QqWDLIdcN2SDoK5J5Gg8HMrqCI6Pfl+rxPb5I1niA+/UkAM+kMCpnekvhSt5AWz2fgkRenkPLA==
+"@docusaurus/plugin-google-analytics@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.1.tgz#e3b84237aad2e94dcd1cf1810c1c9bc3d94f186d"
+  integrity sha512-d5qb+ZeQcg1Czoxc+RacETjLdp2sN/TAd7PGN/GrvtijCdgNmvVAtZ9QgajBTG0YbJFVPTeZ39ad2bpoOexX0w==
   dependencies:
-    "@docusaurus/core" "2.0.0-rc.1"
-    "@docusaurus/types" "2.0.0-rc.1"
-    "@docusaurus/utils-validation" "2.0.0-rc.1"
+    "@docusaurus/core" "2.0.1"
+    "@docusaurus/types" "2.0.1"
+    "@docusaurus/utils-validation" "2.0.1"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-google-gtag@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-rc.1.tgz#61698fdc41a4ace912fb8f6c834efd288edad3c0"
-  integrity sha512-yE1Et9hhhX9qMRnMJzpNq0854qIYiSEc2dZaXNk537HN7Q0rKkr/YONUHz2iqNYwPX2hGOY4LdpTxlMP88uVhA==
+"@docusaurus/plugin-google-gtag@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.1.tgz#4cbcf9d520f7ec8124679fbe00867f2299a2f6bb"
+  integrity sha512-qiRufJe2FvIyzICbkjm4VbVCI1hyEju/CebfDKkKh2ZtV4q6DM1WZG7D6VoQSXL8MrMFB895gipOM4BwdM8VsQ==
   dependencies:
-    "@docusaurus/core" "2.0.0-rc.1"
-    "@docusaurus/types" "2.0.0-rc.1"
-    "@docusaurus/utils-validation" "2.0.0-rc.1"
+    "@docusaurus/core" "2.0.1"
+    "@docusaurus/types" "2.0.1"
+    "@docusaurus/utils-validation" "2.0.1"
     tslib "^2.4.0"
 
-"@docusaurus/plugin-sitemap@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-rc.1.tgz#0b638e774b253d90e9f2d11663e961250f557bc4"
-  integrity sha512-5JmbNpssUF03odFM4ArvIsrO9bv7HnAJ0VtefXhh0WBpaFs8NgI3rTkCTFimvtRQjDR9U2bh23fXz2vjQQz6oA==
+"@docusaurus/plugin-sitemap@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.1.tgz#6f8edb82b745b040d6b1495e2798396f63e50289"
+  integrity sha512-KcYuIUIp2JPzUf+Xa7W2BSsjLgN1/0h+VAz7D/C3RYjAgC5ApPX8wO+TECmGfunl/m7WKGUmLabfOon/as64kQ==
   dependencies:
-    "@docusaurus/core" "2.0.0-rc.1"
-    "@docusaurus/logger" "2.0.0-rc.1"
-    "@docusaurus/types" "2.0.0-rc.1"
-    "@docusaurus/utils" "2.0.0-rc.1"
-    "@docusaurus/utils-common" "2.0.0-rc.1"
-    "@docusaurus/utils-validation" "2.0.0-rc.1"
+    "@docusaurus/core" "2.0.1"
+    "@docusaurus/logger" "2.0.1"
+    "@docusaurus/types" "2.0.1"
+    "@docusaurus/utils" "2.0.1"
+    "@docusaurus/utils-common" "2.0.1"
+    "@docusaurus/utils-validation" "2.0.1"
     fs-extra "^10.1.0"
     sitemap "^7.1.1"
     tslib "^2.4.0"
 
-"@docusaurus/preset-classic@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.0.0-rc.1.tgz#5e5b1cf80b3dd4e2c3f824c78a111f105858d853"
-  integrity sha512-5jjTVZkhArjyoNHwCI9x4PSG0zPmBJILjZLVrxPcHpm/K0ltkYcp6J3GxYpf5EbMuOh5+yCWM63cSshGcNOo3Q==
+"@docusaurus/preset-classic@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.0.1.tgz#21a806e16b61026d2a0efa6ca97e17397065d894"
+  integrity sha512-nOoniTg46My1qdDlLWeFs55uEmxOJ+9WMF8KKG8KMCu5LAvpemMi7rQd4x8Tw+xiPHZ/sQzH9JmPTMPRE4QGPw==
   dependencies:
-    "@docusaurus/core" "2.0.0-rc.1"
-    "@docusaurus/plugin-content-blog" "2.0.0-rc.1"
-    "@docusaurus/plugin-content-docs" "2.0.0-rc.1"
-    "@docusaurus/plugin-content-pages" "2.0.0-rc.1"
-    "@docusaurus/plugin-debug" "2.0.0-rc.1"
-    "@docusaurus/plugin-google-analytics" "2.0.0-rc.1"
-    "@docusaurus/plugin-google-gtag" "2.0.0-rc.1"
-    "@docusaurus/plugin-sitemap" "2.0.0-rc.1"
-    "@docusaurus/theme-classic" "2.0.0-rc.1"
-    "@docusaurus/theme-common" "2.0.0-rc.1"
-    "@docusaurus/theme-search-algolia" "2.0.0-rc.1"
-    "@docusaurus/types" "2.0.0-rc.1"
+    "@docusaurus/core" "2.0.1"
+    "@docusaurus/plugin-content-blog" "2.0.1"
+    "@docusaurus/plugin-content-docs" "2.0.1"
+    "@docusaurus/plugin-content-pages" "2.0.1"
+    "@docusaurus/plugin-debug" "2.0.1"
+    "@docusaurus/plugin-google-analytics" "2.0.1"
+    "@docusaurus/plugin-google-gtag" "2.0.1"
+    "@docusaurus/plugin-sitemap" "2.0.1"
+    "@docusaurus/theme-classic" "2.0.1"
+    "@docusaurus/theme-common" "2.0.1"
+    "@docusaurus/theme-search-algolia" "2.0.1"
+    "@docusaurus/types" "2.0.1"
 
 "@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
@@ -2647,23 +2647,23 @@
     "@types/react" "*"
     prop-types "^15.6.2"
 
-"@docusaurus/theme-classic@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.0.0-rc.1.tgz#4ab30745e6b03b0f277837debae786a0a83aee6a"
-  integrity sha512-qNiz7ieeq3AC+V8TbW6S63pWLJph1CbzWDDPTqxDLHgA8VQaNaSmJM8S92pH+yKALRb9u14ogjjYYc75Nj2JmQ==
+"@docusaurus/theme-classic@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.0.1.tgz#043b6fcd2ecb2aecd134419b198c9f519029d5e7"
+  integrity sha512-0jfigiqkUwIuKOw7Me5tqUM9BBvoQX7qqeevx7v4tkYQexPhk3VYSZo7aRuoJ9oyW5makCTPX551PMJzmq7+sw==
   dependencies:
-    "@docusaurus/core" "2.0.0-rc.1"
-    "@docusaurus/mdx-loader" "2.0.0-rc.1"
-    "@docusaurus/module-type-aliases" "2.0.0-rc.1"
-    "@docusaurus/plugin-content-blog" "2.0.0-rc.1"
-    "@docusaurus/plugin-content-docs" "2.0.0-rc.1"
-    "@docusaurus/plugin-content-pages" "2.0.0-rc.1"
-    "@docusaurus/theme-common" "2.0.0-rc.1"
-    "@docusaurus/theme-translations" "2.0.0-rc.1"
-    "@docusaurus/types" "2.0.0-rc.1"
-    "@docusaurus/utils" "2.0.0-rc.1"
-    "@docusaurus/utils-common" "2.0.0-rc.1"
-    "@docusaurus/utils-validation" "2.0.0-rc.1"
+    "@docusaurus/core" "2.0.1"
+    "@docusaurus/mdx-loader" "2.0.1"
+    "@docusaurus/module-type-aliases" "2.0.1"
+    "@docusaurus/plugin-content-blog" "2.0.1"
+    "@docusaurus/plugin-content-docs" "2.0.1"
+    "@docusaurus/plugin-content-pages" "2.0.1"
+    "@docusaurus/theme-common" "2.0.1"
+    "@docusaurus/theme-translations" "2.0.1"
+    "@docusaurus/types" "2.0.1"
+    "@docusaurus/utils" "2.0.1"
+    "@docusaurus/utils-common" "2.0.1"
+    "@docusaurus/utils-validation" "2.0.1"
     "@mdx-js/react" "^1.6.22"
     clsx "^1.2.1"
     copy-text-to-clipboard "^3.0.1"
@@ -2678,17 +2678,17 @@
     tslib "^2.4.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-common@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-2.0.0-rc.1.tgz#ea5d9732a16b03b488555e50107161bfa2abad98"
-  integrity sha512-1r9ZLKD9SeoCYVzWzcdR79Dia4ANlrlRjNl6uzETOEybjK6FF7yEa9Yra8EJcOCbi3coyYz5xFh/r1YHFTFHug==
+"@docusaurus/theme-common@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-2.0.1.tgz#9594d58fbef11fe480967b5ce4cdbb3cd78d9ca3"
+  integrity sha512-I3b6e/ryiTQMsbES40cP0DRGnfr0E2qghVq+XecyMKjBPejISoSFEDn0MsnbW8Q26k1Dh/0qDH8QKDqaZZgLhA==
   dependencies:
-    "@docusaurus/mdx-loader" "2.0.0-rc.1"
-    "@docusaurus/module-type-aliases" "2.0.0-rc.1"
-    "@docusaurus/plugin-content-blog" "2.0.0-rc.1"
-    "@docusaurus/plugin-content-docs" "2.0.0-rc.1"
-    "@docusaurus/plugin-content-pages" "2.0.0-rc.1"
-    "@docusaurus/utils" "2.0.0-rc.1"
+    "@docusaurus/mdx-loader" "2.0.1"
+    "@docusaurus/module-type-aliases" "2.0.1"
+    "@docusaurus/plugin-content-blog" "2.0.1"
+    "@docusaurus/plugin-content-docs" "2.0.1"
+    "@docusaurus/plugin-content-pages" "2.0.1"
+    "@docusaurus/utils" "2.0.1"
     "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router-config" "*"
@@ -2698,19 +2698,19 @@
     tslib "^2.4.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-search-algolia@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-rc.1.tgz#e78c0aeaea6a3717ae3a6ecd75a8652bd7c8e974"
-  integrity sha512-H5yq6V/B4qo6GZrDKMbeSpk3T9e9K2MliDzLonRu0w3QHW9orVGe0c/lZvRbGlDZjnsOo7XGddhXXIDWGwnpaA==
+"@docusaurus/theme-search-algolia@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.1.tgz#0aab8407b2163f67eb4c48f1de33944e1695fa74"
+  integrity sha512-cw3NaOSKbYlsY6uNj4PgO+5mwyQ3aEWre5RlmvjStaz2cbD15Nr69VG8Rd/F6Q5VsCT8BvSdkPDdDG5d/ACexg==
   dependencies:
     "@docsearch/react" "^3.1.1"
-    "@docusaurus/core" "2.0.0-rc.1"
-    "@docusaurus/logger" "2.0.0-rc.1"
-    "@docusaurus/plugin-content-docs" "2.0.0-rc.1"
-    "@docusaurus/theme-common" "2.0.0-rc.1"
-    "@docusaurus/theme-translations" "2.0.0-rc.1"
-    "@docusaurus/utils" "2.0.0-rc.1"
-    "@docusaurus/utils-validation" "2.0.0-rc.1"
+    "@docusaurus/core" "2.0.1"
+    "@docusaurus/logger" "2.0.1"
+    "@docusaurus/plugin-content-docs" "2.0.1"
+    "@docusaurus/theme-common" "2.0.1"
+    "@docusaurus/theme-translations" "2.0.1"
+    "@docusaurus/utils" "2.0.1"
+    "@docusaurus/utils-validation" "2.0.1"
     algoliasearch "^4.13.1"
     algoliasearch-helper "^3.10.0"
     clsx "^1.2.1"
@@ -2720,18 +2720,18 @@
     tslib "^2.4.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-translations@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-translations/-/theme-translations-2.0.0-rc.1.tgz#bd647f78c741ee7f6c6d2cbbd3e3f282ef2f89ad"
-  integrity sha512-JLhNdlnbQhxVQzOnLyiCaTzKFa1lpVrM3nCrkGQKscoG2rY6ARGYMgMN2DkoH6hm7TflQ8+PE1S5MzzASeLs4Q==
+"@docusaurus/theme-translations@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-translations/-/theme-translations-2.0.1.tgz#955a687c974265a811bfc743d98ef3eab0379100"
+  integrity sha512-v1MYYlbsdX+rtKnXFcIAn9ar0Z6K0yjqnCYS0p/KLCLrfJwfJ8A3oRJw2HiaIb8jQfk1WMY2h5Qi1p4vHOekQw==
   dependencies:
     fs-extra "^10.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/types@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.0.0-rc.1.tgz#032f8afde6b4878e37f984b9949a96b150103c21"
-  integrity sha512-wX25FOZa/aKnCGA5ljWPaDpMW3TuTbs0BtjQ8WTC557p8zDvuz4r+g2/FPHsgWE0TKwUMf4usQU1m3XpJLPN+g==
+"@docusaurus/types@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.0.1.tgz#8696a70e85c4b9be80b38ac592d520f6fe72618b"
+  integrity sha512-o+4hAFWkj3sBszVnRTAnNqtAIuIW0bNaYyDwQhQ6bdz3RAPEq9cDKZxMpajsj4z2nRty8XjzhyufAAjxFTyrfg==
   dependencies:
     "@types/history" "^4.7.11"
     "@types/react" "*"
@@ -2742,30 +2742,30 @@
     webpack "^5.73.0"
     webpack-merge "^5.8.0"
 
-"@docusaurus/utils-common@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-2.0.0-rc.1.tgz#3e233a28794325d5d9d3af3f7b1c22b59aa8b847"
-  integrity sha512-+iZICpeFPZJ9oGJXuG92WTWee6WRnVx5BdzlcfuKf/f5KQX8PvwXR2tDME78FGGhShB8zr+vjuNEXuLvXT7j2A==
+"@docusaurus/utils-common@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-2.0.1.tgz#b6f2b029547f739e1431ec84abd16974edf495e0"
+  integrity sha512-kajCCDCXRd1HFH5EUW31MPaQcsyNlGakpkDoTBtBvpa4EIPvWaSKy7TIqYKHrZjX4tnJ0YbEJvaXfjjgdq5xSg==
   dependencies:
     tslib "^2.4.0"
 
-"@docusaurus/utils-validation@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-2.0.0-rc.1.tgz#dded12f036cda8a54a19e01694b35859fe0cf1d5"
-  integrity sha512-lj36gm9Ksu4tt/EUeLDWoMbXe3sfBxeIPIUUdqYcBYkF/rpQkh+uL/dncjNGiw6uvBOqXhOfsFVP045HtgShVw==
+"@docusaurus/utils-validation@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-2.0.1.tgz#69f7d4944288d71f00fdba6dde10f05008f04308"
+  integrity sha512-f14AnwFBy4/1A19zWthK+Ii80YDz+4qt8oPpK3julywXsheSxPBqgsND3LVBBvB2p3rJHvbo2m3HyB9Tco1JRw==
   dependencies:
-    "@docusaurus/logger" "2.0.0-rc.1"
-    "@docusaurus/utils" "2.0.0-rc.1"
+    "@docusaurus/logger" "2.0.1"
+    "@docusaurus/utils" "2.0.1"
     joi "^17.6.0"
     js-yaml "^4.1.0"
     tslib "^2.4.0"
 
-"@docusaurus/utils@2.0.0-rc.1":
-  version "2.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.0.0-rc.1.tgz#53584b800df9e13864d5ef1a76aa7655a90ec86e"
-  integrity sha512-ym9I1OwIYbKs1LGaUajaA/vDG8VweJj/6YoZjHp+eDQHhTRIrHXiYoGDqorafRhftKwnA1EnyomuXpNd9bq8Gg==
+"@docusaurus/utils@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.0.1.tgz#37b4b42e29175e5d2d811fcbf9f93bffeca7c353"
+  integrity sha512-u2Vdl/eoVwMfUjDCkg7FjxoiwFs/XhVVtNxQEw8cvB+qaw6QWyT73m96VZzWtUb1fDOefHoZ+bZ0ObFeKk9lMQ==
   dependencies:
-    "@docusaurus/logger" "2.0.0-rc.1"
+    "@docusaurus/logger" "2.0.1"
     "@svgr/webpack" "^6.2.1"
     file-loader "^6.2.0"
     fs-extra "^10.1.0"

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,21 @@
+# Sticky Header Example
+
+To run example app:
+
+## Android
+
+```sh
+yarn android
+```
+
+## iOS
+
+```sh
+yarn ios
+```
+
+## Web
+
+```sh
+yarn web
+```

--- a/example/src/navigation/AppNavigator.tsx
+++ b/example/src/navigation/AppNavigator.tsx
@@ -69,6 +69,7 @@ const AppNavigator: React.FC = () => (
       <Stack.Screen
         name={ROUTES.TABBED_HEADER_WITH_SECTION_LISTS}
         component={TabbedHeaderWithSectionListsExample}
+        options={{ headerShown: true }}
       />
       <Stack.Screen
         name={ROUTES.TABBED_HEADER_FLASHLIST}

--- a/example/src/screens/additionalExamples/StickyHeaderFlashListExample.tsx
+++ b/example/src/screens/additionalExamples/StickyHeaderFlashListExample.tsx
@@ -1,9 +1,12 @@
 import { FlashList } from '@shopify/flash-list';
 import * as React from 'react';
-import { Platform, StatusBar } from 'react-native';
+import { Platform, StatusBar, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import type { StickyHeaderFlashListProps } from 'react-native-sticky-parallax-header';
-import { withStickyHeaderFlashList } from 'react-native-sticky-parallax-header';
+import {
+  useStickyHeaderFlashListScrollProps,
+  withStickyHeaderFlashList,
+} from 'react-native-sticky-parallax-header';
 
 import { DATA } from '../../assets/data/paragraphs';
 import { Header } from '../../components/primitiveComponents/Header';
@@ -21,12 +24,24 @@ const data = DATA.concat(DATA)
   .concat(DATA)
   .concat(DATA);
 
+const PARALLAX_HEIGHT = 330;
+const SNAP_START_THRESHOLD = 50;
+const SNAP_STOP_THRESHOLD = 330;
+
 const StickyHeaderFlashList = withStickyHeaderFlashList(FlashList) as (
   props: StickyHeaderFlashListProps<string> & React.RefAttributes<FlashList<string>>
 ) => React.ReactElement;
 
 export const StickyHeaderFlashListExample: React.FC = () => {
   const [refreshing, setRefreshing] = React.useState(false);
+
+  const { onMomentumScrollEnd, onScroll, onScrollEndDrag, scrollHeight, scrollViewRef } =
+    useStickyHeaderFlashListScrollProps({
+      parallaxHeight: PARALLAX_HEIGHT,
+      snapStartThreshold: SNAP_START_THRESHOLD,
+      snapStopThreshold: SNAP_STOP_THRESHOLD,
+      snapToEdge: true,
+    });
 
   async function onRefresh() {
     setRefreshing(true);
@@ -37,8 +52,10 @@ export const StickyHeaderFlashListExample: React.FC = () => {
   return (
     <SafeAreaView style={screenStyles.screenContainer}>
       <StickyHeaderFlashList
+        ref={scrollViewRef}
         containerStyle={screenStyles.stretchContainer}
         data={data}
+        decelerationRate="fast"
         keyExtractor={(_, index) => `${index}`}
         /**
          * Refresh control is not implemented on web, which causes styles as margin or padding
@@ -48,15 +65,32 @@ export const StickyHeaderFlashListExample: React.FC = () => {
          */
         {...Platform.select({ native: { onRefresh } })}
         refreshing={refreshing}
-        renderHeader={() => <Header />}
+        onScroll={onScroll}
+        onMomentumScrollEnd={onMomentumScrollEnd}
+        onScrollEndDrag={onScrollEndDrag}
+        renderHeader={() => {
+          return (
+            <View pointerEvents="box-none" style={[styles.center, { height: scrollHeight }]}>
+              <Header />
+            </View>
+          );
+        }}
         renderItem={({ item }) => {
           return <Paragraph text={item} />;
         }}
         renderTabs={() => <Tabs />}
         scrollEventThrottle={16}
         estimatedItemSize={400}
+        showsVerticalScrollIndicator={false}
       />
       <StatusBar backgroundColor="transparent" barStyle="dark-content" />
     </SafeAreaView>
   );
 };
+
+const styles = StyleSheet.create({
+  center: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/example/src/screens/additionalExamples/TabbedHeaderWithSectionLists.tsx
+++ b/example/src/screens/additionalExamples/TabbedHeaderWithSectionLists.tsx
@@ -70,6 +70,7 @@ export const TabbedHeaderWithSectionListsExample: React.FC = () => {
         containerStyle={screenStyles.stretchContainer}
         foregroundImage={photosPortraitMe}
         disableScrollToPosition={true}
+        enableSafeAreaTopInset={false}
         rememberTabScrollPosition={false}
         logo={logo}
         title={"Mornin' Mark! \nReady for a quiz?"}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "pods": "cd example && pod-install && cd ..",
     "bootstrap": "yarn example && yarn && yarn pods",
     "prepush": "yarn lint && yarn typescript",
+    "example:android": "yarn example android",
+    "example:ios": "yarn example ios",
+    "example:web": "yarn example web",
     "example:studio": "studio example/android",
     "example:xcode": "xed example/ios"
   },

--- a/src/predefinedComponents/AvatarHeader/AvatarHeaderFlatList.tsx
+++ b/src/predefinedComponents/AvatarHeader/AvatarHeaderFlatList.tsx
@@ -18,6 +18,7 @@ function AvatarHeaderFlatListInner<ItemT>(
     contentContainerStyle,
     data,
     decelerationRate = 'fast',
+    enableSafeAreaTopInset = true,
     keyExtractor,
     leftTopIcon,
     leftTopIconAccessibilityLabel,
@@ -55,6 +56,7 @@ function AvatarHeaderFlatListInner<ItemT>(
       ) : (
         <HeaderBar
           backgroundColor={backgroundColor}
+          enableSafeAreaTopInset={enableSafeAreaTopInset}
           height={parallaxHeight}
           leftTopIcon={leftTopIcon}
           leftTopIconAccessibilityLabel={leftTopIconAccessibilityLabel}

--- a/src/predefinedComponents/AvatarHeader/AvatarHeaderProps.ts
+++ b/src/predefinedComponents/AvatarHeader/AvatarHeaderProps.ts
@@ -9,6 +9,7 @@ import type {
 import type { IconProps, SharedPredefinedProps } from '../common/SharedProps';
 
 export interface AvatarHeaderSharedProps extends IconProps, SharedPredefinedProps {
+  enableSafeAreaTopInset?: boolean;
   hasBorderRadius?: boolean;
   image?: ImageSourcePropType;
   subtitle?: string;

--- a/src/predefinedComponents/AvatarHeader/AvatarHeaderScrollView.tsx
+++ b/src/predefinedComponents/AvatarHeader/AvatarHeaderScrollView.tsx
@@ -16,6 +16,7 @@ export const AvatarHeaderScrollView = React.forwardRef<ScrollView, AvatarHeaderS
       children,
       contentContainerStyle,
       decelerationRate = 'fast',
+      enableSafeAreaTopInset = true,
       leftTopIcon,
       leftTopIconAccessibilityLabel,
       leftTopIconOnPress,
@@ -51,6 +52,7 @@ export const AvatarHeaderScrollView = React.forwardRef<ScrollView, AvatarHeaderS
         ) : (
           <HeaderBar
             backgroundColor={backgroundColor}
+            enableSafeAreaTopInset={enableSafeAreaTopInset}
             height={parallaxHeight}
             leftTopIcon={leftTopIcon}
             leftTopIconAccessibilityLabel={leftTopIconAccessibilityLabel}

--- a/src/predefinedComponents/AvatarHeader/AvatarHeaderSectionList.tsx
+++ b/src/predefinedComponents/AvatarHeader/AvatarHeaderSectionList.tsx
@@ -17,6 +17,7 @@ function AvatarHeaderSectionListInner<ItemT, SectionT>(
     backgroundColor,
     contentContainerStyle,
     decelerationRate = 'fast',
+    enableSafeAreaTopInset = true,
     leftTopIcon,
     leftTopIconAccessibilityLabel,
     leftTopIconOnPress,
@@ -56,6 +57,7 @@ function AvatarHeaderSectionListInner<ItemT, SectionT>(
       ) : (
         <HeaderBar
           backgroundColor={backgroundColor}
+          enableSafeAreaTopInset={enableSafeAreaTopInset}
           height={parallaxHeight}
           leftTopIcon={leftTopIcon}
           leftTopIconAccessibilityLabel={leftTopIconAccessibilityLabel}

--- a/src/predefinedComponents/AvatarHeader/components/HeaderBar.tsx
+++ b/src/predefinedComponents/AvatarHeader/components/HeaderBar.tsx
@@ -8,6 +8,7 @@ import type {
 } from 'react-native';
 import { Pressable, StyleSheet, View } from 'react-native';
 import Animated, { Extrapolate, interpolate, useAnimatedStyle } from 'react-native-reanimated';
+import type { Edge } from 'react-native-safe-area-context';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { colors, commonStyles } from '../../../constants';
@@ -25,6 +26,7 @@ const HIT_SLOP = {
 
 interface HeaderProps extends IconProps {
   backgroundColor?: ColorValue;
+  enableSafeAreaTopInset?: boolean;
   height: number;
   image?: ImageSourcePropType;
   scrollValue: Animated.SharedValue<number>;
@@ -35,6 +37,7 @@ interface HeaderProps extends IconProps {
 
 export const HeaderBar: React.FC<HeaderProps> = ({
   backgroundColor,
+  enableSafeAreaTopInset,
   height,
   image,
   leftTopIcon,
@@ -86,11 +89,14 @@ export const HeaderBar: React.FC<HeaderProps> = ({
     styles.headerTitleContainerMarginLeft,
     styles.headerTitleContainerMarginEnd
   );
+  const safeAreaEdges: Edge[] = ['left', 'right'];
+
+  if (enableSafeAreaTopInset) {
+    safeAreaEdges.push('top');
+  }
 
   return (
-    <SafeAreaView
-      edges={['left', 'top', 'right']}
-      style={[commonStyles.headerWrapper, { backgroundColor }]}>
+    <SafeAreaView edges={safeAreaEdges} style={[commonStyles.headerWrapper, { backgroundColor }]}>
       <Pressable
         accessibilityLabel={leftTopIconAccessibilityLabel}
         accessibilityRole="button"

--- a/src/predefinedComponents/AvatarHeader/withAvatarHeaderFlashList.tsx
+++ b/src/predefinedComponents/AvatarHeader/withAvatarHeaderFlashList.tsx
@@ -23,6 +23,7 @@ export function withAvatarHeaderFlashList<ItemT>(
     const {
       backgroundColor,
       decelerationRate = 'fast',
+      enableSafeAreaTopInset = true,
       leftTopIcon,
       leftTopIconAccessibilityLabel,
       leftTopIconOnPress,
@@ -58,6 +59,7 @@ export function withAvatarHeaderFlashList<ItemT>(
         ) : (
           <HeaderBar
             backgroundColor={backgroundColor}
+            enableSafeAreaTopInset={enableSafeAreaTopInset}
             height={parallaxHeight}
             leftTopIcon={leftTopIcon}
             leftTopIconAccessibilityLabel={leftTopIconAccessibilityLabel}

--- a/src/predefinedComponents/DetailsHeader/DetailsHeaderFlatList.tsx
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeaderFlatList.tsx
@@ -18,6 +18,7 @@ function DetailsHeaderFlatListInner<ItemT>(
     contentContainerStyle,
     data,
     decelerationRate = 'fast',
+    enableSafeAreaTopInset = true,
     keyExtractor,
     leftTopIcon,
     leftTopIconAccessibilityLabel,
@@ -54,6 +55,7 @@ function DetailsHeaderFlatListInner<ItemT>(
       ) : (
         <HeaderBar
           backgroundColor={backgroundColor}
+          enableSafeAreaTopInset={enableSafeAreaTopInset}
           headerTitleContainerAnimatedStyle={headerTitleContainerAnimatedStyle}
           leftTopIcon={leftTopIcon}
           leftTopIconAccessibilityLabel={leftTopIconAccessibilityLabel}

--- a/src/predefinedComponents/DetailsHeader/DetailsHeaderProps.ts
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeaderProps.ts
@@ -13,6 +13,7 @@ export interface DetailsHeaderSharedProps extends IconProps, SharedPredefinedPro
   contentIconNumber?: number;
   contentIconNumberStyle?: StyleProp<TextStyle>;
   contentIconNumberTestID?: string;
+  enableSafeAreaTopInset?: boolean;
   hasBorderRadius?: boolean;
   image?: ImageSourcePropType;
   tabsContainerBackgroundColor?: ColorValue;

--- a/src/predefinedComponents/DetailsHeader/DetailsHeaderScrollView.tsx
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeaderScrollView.tsx
@@ -16,6 +16,7 @@ export const DetailsHeaderScrollView = React.forwardRef<ScrollView, DetailsHeade
       children,
       contentContainerStyle,
       decelerationRate = 'fast',
+      enableSafeAreaTopInset = true,
       leftTopIcon,
       leftTopIconAccessibilityLabel,
       leftTopIconOnPress,
@@ -50,6 +51,7 @@ export const DetailsHeaderScrollView = React.forwardRef<ScrollView, DetailsHeade
         ) : (
           <HeaderBar
             backgroundColor={backgroundColor}
+            enableSafeAreaTopInset={enableSafeAreaTopInset}
             headerTitleContainerAnimatedStyle={headerTitleContainerAnimatedStyle}
             leftTopIcon={leftTopIcon}
             leftTopIconAccessibilityLabel={leftTopIconAccessibilityLabel}

--- a/src/predefinedComponents/DetailsHeader/DetailsHeaderSectionList.tsx
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeaderSectionList.tsx
@@ -17,6 +17,7 @@ function DetailsHeaderSectionListInner<ItemT, SectionT>(
     backgroundColor,
     contentContainerStyle,
     decelerationRate = 'fast',
+    enableSafeAreaTopInset = true,
     leftTopIcon,
     leftTopIconAccessibilityLabel,
     leftTopIconOnPress,
@@ -55,6 +56,7 @@ function DetailsHeaderSectionListInner<ItemT, SectionT>(
       ) : (
         <HeaderBar
           backgroundColor={backgroundColor}
+          enableSafeAreaTopInset={enableSafeAreaTopInset}
           headerTitleContainerAnimatedStyle={headerTitleContainerAnimatedStyle}
           leftTopIcon={leftTopIcon}
           leftTopIconAccessibilityLabel={leftTopIconAccessibilityLabel}

--- a/src/predefinedComponents/DetailsHeader/components/HeaderBar.tsx
+++ b/src/predefinedComponents/DetailsHeader/components/HeaderBar.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import type { ColorValue, StyleProp, TextStyle } from 'react-native';
 import { Pressable, StyleSheet, Text } from 'react-native';
 import Animated from 'react-native-reanimated';
+import type { Edge } from 'react-native-safe-area-context';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { colors, commonStyles } from '../../../constants';
@@ -10,6 +11,7 @@ import IconRenderer from '../../common/components/IconRenderer';
 
 interface HeaderBarProps extends IconProps {
   backgroundColor?: ColorValue;
+  enableSafeAreaTopInset?: boolean;
   headerTitleContainerAnimatedStyle: { opacity: number };
   title?: string;
   titleStyle?: StyleProp<TextStyle>;
@@ -25,6 +27,7 @@ const HIT_SLOP = {
 
 export const HeaderBar: React.FC<HeaderBarProps> = ({
   backgroundColor,
+  enableSafeAreaTopInset,
   headerTitleContainerAnimatedStyle,
   leftTopIcon,
   leftTopIconAccessibilityLabel,
@@ -38,10 +41,14 @@ export const HeaderBar: React.FC<HeaderBarProps> = ({
   titleStyle,
   titleTestID = 'DetailsHeaderBarTitleTestID',
 }) => {
+  const safeAreaEdges: Edge[] = ['left', 'right'];
+
+  if (enableSafeAreaTopInset) {
+    safeAreaEdges.push('top');
+  }
+
   return (
-    <SafeAreaView
-      edges={['left', 'top', 'right']}
-      style={[commonStyles.headerWrapper, { backgroundColor }]}>
+    <SafeAreaView edges={safeAreaEdges} style={[commonStyles.headerWrapper, { backgroundColor }]}>
       <Pressable
         accessibilityLabel={leftTopIconAccessibilityLabel}
         accessibilityRole="button"

--- a/src/predefinedComponents/DetailsHeader/withDetailsHeaderFlashList.tsx
+++ b/src/predefinedComponents/DetailsHeader/withDetailsHeaderFlashList.tsx
@@ -23,6 +23,7 @@ export function withDetailsHeaderFlashList<ItemT>(
     const {
       backgroundColor,
       decelerationRate = 'fast',
+      enableSafeAreaTopInset = true,
       leftTopIcon,
       leftTopIconAccessibilityLabel,
       leftTopIconOnPress,
@@ -57,6 +58,7 @@ export function withDetailsHeaderFlashList<ItemT>(
         ) : (
           <HeaderBar
             backgroundColor={backgroundColor}
+            enableSafeAreaTopInset={enableSafeAreaTopInset}
             headerTitleContainerAnimatedStyle={headerTitleContainerAnimatedStyle}
             leftTopIcon={leftTopIcon}
             leftTopIconAccessibilityLabel={leftTopIconAccessibilityLabel}

--- a/src/predefinedComponents/TabbedHeader/TabbedHeaderList.tsx
+++ b/src/predefinedComponents/TabbedHeader/TabbedHeaderList.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { SectionList } from 'react-native';
 import { View } from 'react-native';
+import type { Edge } from 'react-native-safe-area-context';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { commonStyles } from '../../constants';
@@ -18,6 +19,7 @@ function TabbedHeaderListInner<ItemT, SectionT>(
     backgroundColor,
     contentContainerStyle,
     decelerationRate = 'fast',
+    enableSafeAreaTopInset = true,
     logo,
     logoContainerStyle,
     logoResizeMode,
@@ -51,13 +53,17 @@ function TabbedHeaderListInner<ItemT, SectionT>(
       ) : logo ? (
         <HeaderBar
           backgroundColor={backgroundColor}
+          enableSafeAreaTopInset={enableSafeAreaTopInset}
           logo={logo}
           logoContainerStyle={logoContainerStyle}
           logoResizeMode={logoResizeMode}
           logoStyle={logoStyle}
         />
       ) : (
-        <SafeAreaView edges={['left', 'top', 'right']} style={commonStyles.stretch} />
+        <SafeAreaView
+          edges={['left', 'right', ...(enableSafeAreaTopInset ? ['top' as Edge] : [])]}
+          style={commonStyles.stretch}
+        />
       )}
       <View style={commonStyles.container}>
         <StickyHeaderSectionList

--- a/src/predefinedComponents/TabbedHeader/TabbedHeaderPager.tsx
+++ b/src/predefinedComponents/TabbedHeader/TabbedHeaderPager.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import type { ScrollView } from 'react-native';
 import { View } from 'react-native';
+import type { Edge } from 'react-native-safe-area-context';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { commonStyles } from '../../constants';
@@ -19,6 +20,7 @@ export const TabbedHeaderPager = React.forwardRef<ScrollView, TabbedHeaderPagerP
       contentContainerStyle,
       disableScrollToPosition,
       decelerationRate = 'fast',
+      enableSafeAreaTopInset = true,
       initialPage,
       logo,
       logoContainerStyle,
@@ -56,13 +58,17 @@ export const TabbedHeaderPager = React.forwardRef<ScrollView, TabbedHeaderPagerP
         ) : logo ? (
           <HeaderBar
             backgroundColor={backgroundColor}
+            enableSafeAreaTopInset={enableSafeAreaTopInset}
             logo={logo}
             logoContainerStyle={logoContainerStyle}
             logoResizeMode={logoResizeMode}
             logoStyle={logoStyle}
           />
         ) : (
-          <SafeAreaView edges={['left', 'top', 'right']} style={commonStyles.stretch} />
+          <SafeAreaView
+            edges={['left', 'right', ...(enableSafeAreaTopInset ? ['top' as Edge] : [])]}
+            style={commonStyles.stretch}
+          />
         )}
         <View style={commonStyles.container}>
           <StickyHeaderScrollView

--- a/src/predefinedComponents/TabbedHeader/TabbedHeaderProps.ts
+++ b/src/predefinedComponents/TabbedHeader/TabbedHeaderProps.ts
@@ -64,6 +64,7 @@ export interface PagerProps
 }
 
 export interface TabbedHeaderSharedProps extends SharedPredefinedProps, Partial<TabsConfig> {
+  enableSafeAreaTopInset?: boolean;
   foregroundImage?: ImageSourcePropType;
   hasBorderRadius?: boolean;
   logo?: ImageSourcePropType;

--- a/src/predefinedComponents/TabbedHeader/components/HeaderBar.tsx
+++ b/src/predefinedComponents/TabbedHeader/components/HeaderBar.tsx
@@ -8,12 +8,14 @@ import type {
   ViewStyle,
 } from 'react-native';
 import { Image } from 'react-native';
+import type { Edge } from 'react-native-safe-area-context';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { commonStyles } from '../../../constants';
 
 interface HeaderBarProps {
   backgroundColor?: ColorValue;
+  enableSafeAreaTopInset?: boolean;
   logo: ImageSourcePropType;
   logoContainerStyle?: StyleProp<ViewStyle>;
   logoResizeMode?: ImageResizeMode;
@@ -22,14 +24,21 @@ interface HeaderBarProps {
 
 export const HeaderBar: React.FC<HeaderBarProps> = ({
   backgroundColor,
+  enableSafeAreaTopInset,
   logo,
   logoResizeMode,
   logoStyle,
   logoContainerStyle,
 }) => {
+  const safeAreaEdges: Edge[] = ['left', 'right'];
+
+  if (enableSafeAreaTopInset) {
+    safeAreaEdges.push('top');
+  }
+
   return (
     <SafeAreaView
-      edges={['left', 'top', 'right']}
+      edges={safeAreaEdges}
       style={[commonStyles.headerWrapper, logoContainerStyle, { backgroundColor }]}>
       <Image resizeMode={logoResizeMode} source={logo} style={[commonStyles.logo, logoStyle]} />
     </SafeAreaView>

--- a/src/predefinedComponents/TabbedHeader/withTabbedHeaderFlashList.tsx
+++ b/src/predefinedComponents/TabbedHeader/withTabbedHeaderFlashList.tsx
@@ -1,6 +1,7 @@
 import type { FlashList, FlashListProps } from '@shopify/flash-list';
 import * as React from 'react';
 import { View } from 'react-native';
+import type { Edge } from 'react-native-safe-area-context';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { commonStyles } from '../../constants';
@@ -24,6 +25,7 @@ export function withTabbedHeaderFlashList<ItemT>(
     const {
       backgroundColor,
       decelerationRate = 'fast',
+      enableSafeAreaTopInset = true,
       logo,
       logoContainerStyle,
       logoResizeMode,
@@ -54,13 +56,17 @@ export function withTabbedHeaderFlashList<ItemT>(
         ) : logo ? (
           <HeaderBar
             backgroundColor={backgroundColor}
+            enableSafeAreaTopInset={enableSafeAreaTopInset}
             logo={logo}
             logoContainerStyle={logoContainerStyle}
             logoResizeMode={logoResizeMode}
             logoStyle={logoStyle}
           />
         ) : (
-          <SafeAreaView edges={['left', 'top', 'right']} style={commonStyles.stretch} />
+          <SafeAreaView
+            edges={['left', 'right', ...(enableSafeAreaTopInset ? ['top' as Edge] : [])]}
+            style={commonStyles.stretch}
+          />
         )}
         <View style={commonStyles.wrapper}>
           <StickyHeaderFlashList

--- a/src/primitiveComponents/useStickyHeaderFlashListScrollProps.ts
+++ b/src/primitiveComponents/useStickyHeaderFlashListScrollProps.ts
@@ -18,7 +18,7 @@ const VELOCITY_THRESHOLD = 7;
 
 // FIXME: unknown does not work here :/
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function useStickyHeaderFlashListScrollProps<T extends FlashList<any>>(
+export function useStickyHeaderFlashListScrollProps<T extends FlashList<any> = FlashList<any>>(
   props: StickyHeaderSharedProps & StickyHeaderSnapProps
 ) {
   const { responsiveHeight } = useResponsiveSize();


### PR DESCRIPTION
docs: improvements
- add generic type for useStickyHeaderScrollProps
- add examples from example app to docs guides
- add section about custom icons for AvatarHeader & DetailsHeader
chore: upgrade docusaurus to 2.0.1
docs: sticky header flashlist example
feat: enableSafeAreaTopInset prop