### PR TITLE
Fix Get Started lib name readability

### DIFF
--- a/docs/src/components/getStartedSection/GetStartedSection.module.css
+++ b/docs/src/components/getStartedSection/GetStartedSection.module.css
@@ -59,6 +59,7 @@
 
 .libName {
     white-space: nowrap;
+    background-color: var(--ifm-footer-background-color);
 }
 
 @media screen and (max-width: 966px) {


### PR DESCRIPTION
This pull request resolves ???

**Description**
- Fix readability of libName
<!-- Describe, what this pull request is solving. -->
From
<img width="577" alt="Screen Shot 2022-10-06 at 11 17 37 PM" src="https://user-images.githubusercontent.com/5106887/194353458-db300786-e818-440e-911e-6250c0bd366a.png">

To
<img width="600" alt="Screen Shot 2022-10-06 at 11 23 58 PM" src="https://user-images.githubusercontent.com/5106887/194353570-a13aa495-2e78-423a-ae34-3d385851bb1a.png">


