### PR TITLE
fix: paddingBottom should now work

### DIFF
--- a/src/primitiveComponents/useStickyHeaderProps.ts
+++ b/src/primitiveComponents/useStickyHeaderProps.ts
@@ -79,6 +79,17 @@ export function useStickyHeaderProps(
     return 0;
   }, [contentContainerStyle]);
 
+  const contentContainerPaddingBottom = useMemo(() => {
+    const paddingBottom = StyleSheet.flatten(contentContainerStyle)?.paddingBottom;
+
+    if (typeof paddingBottom === 'number') {
+      return paddingBottom;
+    }
+
+    // We do not support string values
+    return 0;
+  }, [contentContainerStyle]);
+
   const listPaddingTop = useMemo(() => {
     const paddingTop = StyleSheet.flatten(style)?.paddingTop;
 
@@ -107,6 +118,7 @@ export function useStickyHeaderProps(
 
   return {
     contentContainerPaddingTop,
+    contentContainerPaddingBottom,
     headerAnimatedStyle,
     headerHeight,
     listPaddingTop,

--- a/src/primitiveComponents/withStickyHeader.tsx
+++ b/src/primitiveComponents/withStickyHeader.tsx
@@ -42,6 +42,7 @@ export function withStickyHeader<T extends React.ComponentType<any>>(component: 
     } = props;
     const {
       contentContainerPaddingTop,
+      contentContainerPaddingBottom,
       headerAnimatedStyle,
       headerHeight,
       listPaddingTop,
@@ -78,7 +79,7 @@ export function withStickyHeader<T extends React.ComponentType<any>>(component: 
           contentContainerStyle={[
             contentContainerStyle,
             { paddingTop: headerHeight + contentContainerPaddingTop },
-            { paddingBottom: tabsHeight },
+            { paddingBottom: tabsHeight + contentContainerPaddingBottom },
           ]}
           onScroll={scrollHandler}
           /**

--- a/src/primitiveComponents/withStickyHeaderFlashList.tsx
+++ b/src/primitiveComponents/withStickyHeaderFlashList.tsx
@@ -33,6 +33,7 @@ export function withStickyHeaderFlashList<T extends React.ComponentType<FlashLis
     } = props;
     const {
       contentContainerPaddingTop,
+      contentContainerPaddingBottom,
       headerAnimatedStyle,
       headerHeight,
       onHeaderLayoutInternal,
@@ -40,6 +41,7 @@ export function withStickyHeaderFlashList<T extends React.ComponentType<FlashLis
       scrollHandler,
       tabsHeight,
     } = useStickyHeaderProps({
+      contentContainerStyle,
       sections: [], // is not needed with FlashList
       onMomentumScrollEnd,
       onScroll,
@@ -50,11 +52,17 @@ export function withStickyHeaderFlashList<T extends React.ComponentType<FlashLis
       return StyleSheet.flatten([
         contentContainerStyle,
         {
-          paddingBottom: tabsHeight,
+          paddingBottom: tabsHeight + contentContainerPaddingBottom,
           paddingTop: headerHeight + contentContainerPaddingTop,
         },
       ]);
-    }, [contentContainerPaddingTop, contentContainerStyle, headerHeight, tabsHeight]);
+    }, [
+      contentContainerPaddingTop,
+      contentContainerPaddingBottom,
+      contentContainerStyle,
+      headerHeight,
+      tabsHeight,
+    ]);
 
     return (
       <View style={[styles.container, containerStyle]}>


### PR DESCRIPTION
This pull request resolves #387 

**Description**

Until now, any paddingBottom in contentContainerStyle was ignored.

**Affected platforms**

- [X] Android
- [X] iOS