### PR TITLE
refactor: move renderHeader from useDetailsHeader hook to DetailsHead…

### DIFF
--- a/src/predefinedComponents/DetailsHeader/DetailsHeaderScrollView.tsx
+++ b/src/predefinedComponents/DetailsHeader/DetailsHeaderScrollView.tsx
@@ -26,6 +26,7 @@ export const DetailsHeaderScrollView = React.forwardRef<ScrollView, DetailsHeade
       nestedScrollEnabled = true,
       overScrollMode = 'never',
       renderHeaderBar,
+      renderHeader,
       rightTopIcon,
       rightTopIconAccessibilityLabel,
       rightTopIconOnPress,
@@ -40,7 +41,6 @@ export const DetailsHeaderScrollView = React.forwardRef<ScrollView, DetailsHeade
       onMomentumScrollEnd,
       onScroll,
       onScrollEndDrag,
-      renderHeader,
       scrollViewRef,
     } = useDetailsHeader<ScrollView>(props);
 


### PR DESCRIPTION
This pull request resolves the issue related to moving the `renderHeader` function from the `useDetailsHeader` hook to the `DetailsHeaderScrollView` props.

**Description**

The `DetailsHeaderScrollView` component had its `renderHeader` function inside the `useDetailsHeader` hook, which made it difficult to customize the header component. This pull request refactors the code to move `renderHeader` as a prop of the DetailsHeaderScrollView component.

**Affected platforms**

- [x] Android
- [x] iOS