### PR TITLE
fixed a bug where the custom renderHeader wouldnt be used

### DIFF
--- a/src/predefinedComponents/DetailsHeader/hooks/useDetailsHeader.tsx
+++ b/src/predefinedComponents/DetailsHeader/hooks/useDetailsHeader.tsx
@@ -38,6 +38,7 @@ export function useDetailsHeader<T extends ScrollComponent>(props: DetailsHeader
     title,
     titleStyle,
     titleTestID,
+    renderHeader
   } = props;
 
   const headerTitleInputRange = [
@@ -51,7 +52,7 @@ export function useDetailsHeader<T extends ScrollComponent>(props: DetailsHeader
     };
   });
 
-  const renderHeader = React.useCallback(() => {
+   const renderHeaderDefault = React.useCallback(() => {
     return (
       <HeaderWrapper
         backgroundColor={backgroundColor}
@@ -112,7 +113,7 @@ export function useDetailsHeader<T extends ScrollComponent>(props: DetailsHeader
     onMomentumScrollEnd,
     onScroll,
     onScrollEndDrag,
-    renderHeader,
+    renderHeader: renderHeader? renderHeader : renderHeaderDefault,
     scrollValue,
     scrollViewRef,
   };


### PR DESCRIPTION
**Description**
This pull request resolves that only the default header would be rendered . same wuth the renderheaderbarcheck is checks if a renderheader is passed and if yes it uses it for the header

**Affected platforms**

- [x ] Android
- [x ] iOS

